### PR TITLE
feat(common): add optional Luxon duration extension for better parsing

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -5,8 +5,20 @@
   "engines": {
     "node": ">=16"
   },
+  "peerDependencies": {
+    "luxon": "^3.3.0"
+  },
+  "peerDependenciesMeta": {
+    "luxon": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/luxon": "^3.2.0",
+    "luxon": "^3.3.0"
+  },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
+    "build": "tsup src/index.ts src/temporal/luxon/index.ts --external=\"@seedcompany/common\" --format cjs,esm --dts --clean",
     "typecheck": "tsc",
     "test": "jest"
   },
@@ -29,6 +41,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts"
+    },
+    "./temporal/luxon": {
+      "import": "./dist/temporal/luxon/index.js",
+      "require": "./dist/temporal/luxon/index.cjs",
+      "types": "./dist/temporal/luxon/index.d.ts"
     }
   }
 }

--- a/packages/common/src/delay.ts
+++ b/packages/common/src/delay.ts
@@ -1,2 +1,14 @@
-export const delay = (ms: number) =>
-  new Promise((resolve) => setTimeout(resolve, ms));
+export interface DelayFn {
+  // eslint-disable-next-line @typescript-eslint/prefer-function-type
+  (ms: number): Promise<void>;
+}
+
+const base = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+export const delayFnImpl = { current: base };
+
+export const delay: DelayFn = (...args) =>
+  // @ts-expect-error Trying to be smart here with a conditional overload.
+  delayFnImpl.current(...args);

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,4 +1,5 @@
 export * from './cache';
+export * from './temporal';
 export * from './async-pool';
 export * from './buffer';
 export * from './delay';

--- a/packages/common/src/temporal/index.ts
+++ b/packages/common/src/temporal/index.ts
@@ -1,0 +1,1 @@
+export * from './parseHumanToDurationLike';

--- a/packages/common/src/temporal/luxon/duration.ts
+++ b/packages/common/src/temporal/luxon/duration.ts
@@ -1,4 +1,4 @@
-import { parseHumanToDurationLike } from '@seedcompany/common';
+import { delayFnImpl, parseHumanToDurationLike } from '@seedcompany/common';
 import { Duration, DurationLike } from 'luxon';
 import { Writable } from 'type-fest';
 import { inspect } from 'util';
@@ -48,4 +48,16 @@ D.fromHuman = (input: string) =>
 Duration.prototype[inspect.custom] = function (this: Duration) {
   const str = this.toHuman({ unitDisplay: 'short' });
   return `[Duration] ${str}`;
+};
+
+declare module '@seedcompany/common' {
+  export interface DelayFn {
+    // eslint-disable-next-line @typescript-eslint/prefer-function-type
+    (duration: DurationIn): Promise<void>;
+  }
+}
+
+delayFnImpl.current = async (duration: DurationIn) => {
+  const d = Duration.from(duration);
+  await new Promise((resolve) => setTimeout(resolve, d.toMillis()));
 };

--- a/packages/common/src/temporal/luxon/duration.ts
+++ b/packages/common/src/temporal/luxon/duration.ts
@@ -1,0 +1,44 @@
+import { parseHumanToDurationLike } from '@seedcompany/common';
+import { Duration, DurationLike } from 'luxon';
+import { Writable } from 'type-fest';
+
+/**
+ * A duration represented as an:
+ * - ISO string {@link Duration.fromISO}
+ * - Human string {@link Duration.fromHuman}
+ * - millisecond number {@link Duration.fromMillis}
+ * - object literal {@link Duration.fromObject}
+ * - Duration instance
+ */
+export type DurationIn = string | DurationLike;
+
+declare module 'luxon/src/duration' {
+  // eslint-disable-next-line @typescript-eslint/no-namespace -- augmenting static class method
+  namespace Duration {
+    /**
+     * Create from ISO, Human, ms number, std object, or another Duration.
+     */
+    export const from: (duration: DurationIn) => Duration;
+    /**
+     * Parse a humanized duration string.
+     * @example
+     * '1hour 20mins'
+     * '27,681 ms'    // numeric separators
+     * '2hr -40mins'  // negatives
+     * '2e3 secs'     // exponents
+     */
+    export const fromHuman: (duration: string) => Duration;
+  }
+}
+
+const D = Duration as Writable<typeof Duration>;
+
+D.from = (input: DurationIn) =>
+  typeof input === 'string'
+    ? input.startsWith('P') || input.startsWith('-P')
+      ? D.fromISO(input)
+      : D.fromHuman(input)
+    : D.fromDurationLike(input);
+
+D.fromHuman = (input: string) =>
+  Duration.fromObject(parseHumanToDurationLike(input));

--- a/packages/common/src/temporal/luxon/duration.ts
+++ b/packages/common/src/temporal/luxon/duration.ts
@@ -1,6 +1,7 @@
 import { parseHumanToDurationLike } from '@seedcompany/common';
 import { Duration, DurationLike } from 'luxon';
 import { Writable } from 'type-fest';
+import { inspect } from 'util';
 
 /**
  * A duration represented as an:
@@ -42,3 +43,9 @@ D.from = (input: DurationIn) =>
 
 D.fromHuman = (input: string) =>
   Duration.fromObject(parseHumanToDurationLike(input));
+
+// @ts-expect-error Yes, it doesn't have to be defined, we are adding it.
+Duration.prototype[inspect.custom] = function (this: Duration) {
+  const str = this.toHuman({ unitDisplay: 'short' });
+  return `[Duration] ${str}`;
+};

--- a/packages/common/src/temporal/luxon/index.ts
+++ b/packages/common/src/temporal/luxon/index.ts
@@ -1,0 +1,1 @@
+export * from './duration';

--- a/packages/common/src/temporal/parseHumanToDurationLike.test.ts
+++ b/packages/common/src/temporal/parseHumanToDurationLike.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@jest/globals';
+import { DurationLikeObject } from 'luxon';
+import { parseHumanToDurationLike } from './parseHumanToDurationLike';
+
+const full = {
+  years: 1,
+  months: 2,
+  weeks: 3,
+  days: 4,
+  hours: 5,
+  minutes: 6,
+  seconds: 7,
+  milliseconds: 8,
+};
+test.each([
+  [
+    '1 years, 2 months, 3 weeks, 4 days, 5 hours, 6 minutes, 7 seconds, 8 milliseconds',
+    full,
+  ],
+  ['1 year 2 month 3 week 4 day 5 hour 6 minute 7 second 8 millisecond', full],
+  ['1year 2month 3week 4day 5hour 6minute 7second 8millisecond', full],
+  ['1yrs 2months 3wks 4days 5hrs 6mins 7secs 8ms', full],
+  ['1yr 2month 3wk 4day 5hr 6min 7sec 8', full],
+  ['1y 2month 3w 4d 5h 6m 7s 8', full],
+  ['27,681 ms', { milliseconds: 27681 }],
+  ['27,681', { milliseconds: 27681 }],
+  ['2hr -40m', { hours: 2, minutes: -40 }],
+  ['2hr-40m', { hours: 2, minutes: -40 }],
+  ['2hr,4,200m', { hours: 2, minutes: 4200 }],
+  ['2e3 secs', { seconds: 2e3 }],
+])('valid cases', (input: string, output: DurationLikeObject) => {
+  expect(parseHumanToDurationLike(input)).toEqual(output);
+});
+
+test('unknown case', () => {
+  expect(() => parseHumanToDurationLike('5 x')).toThrowError(
+    new Error('Unknown unit: x'),
+  );
+});

--- a/packages/common/src/temporal/parseHumanToDurationLike.ts
+++ b/packages/common/src/temporal/parseHumanToDurationLike.ts
@@ -1,0 +1,69 @@
+/**
+ * Parse a humanized duration string into a DurationLike object.
+ *
+ * Output from this can be passed into Luxon or Temporal Duration
+ *
+ * @example
+ * '1hour 20mins'
+ * '27,681 ms'    // numeric separators
+ * '2hr -40mins'  // negatives
+ * '2e3 secs'     // exponents
+ */
+export const parseHumanToDurationLike = (input: string) => {
+  // Adapted from https://github.com/jkroso/parse-duration
+  const durationRE =
+    /(-?(?:\d+\.?\d*|\d*\.?\d+)(?:e[-+]?\d+)?)\s*([\p{L}]*)/giu;
+  input = input.replace(/(\d)[,_](\d)/g, '$1$2');
+  const result: { [K in Units]?: number } = {};
+  input.replace(durationRE, (_, num, unit) => {
+    result[normalizedUnit(unit)] = parseFloat(num);
+    return '';
+  });
+  return result;
+};
+
+const normalizedUnit = (unit: string): Units => {
+  unit = unit.toLowerCase();
+  // Handle specially here before plural is removed, conflicting with min/sec.
+  if (unit === '' || unit === 'ms') {
+    return 'milliseconds';
+  }
+  unit = unit.replace(/s$/, '');
+  /* eslint-disable prettier/prettier */
+  switch (unit) {
+    case 'sec': case '': return 'seconds';
+    case 'min': case 'm': return 'minutes';
+    case 'hr': case 'h': return 'hours';
+    case 'd': return 'days';
+    case 'wk': case 'w': return 'weeks';
+    case 'yr': case 'y': return 'years';
+  }
+  /* eslint-enable prettier/prettier */
+
+  if (validUnits.has(unit as Unit)) {
+    return (unit + 's') as Units;
+  }
+  throw new Error('Unknown unit: ' + unit);
+};
+
+const validUnits = new Set<Unit>([
+  'millisecond',
+  'second',
+  'minute',
+  'hour',
+  'day',
+  'week',
+  'month',
+  'year',
+]);
+
+type Units = `${Unit}s`;
+type Unit =
+  | 'millisecond'
+  | 'second'
+  | 'minute'
+  | 'hour'
+  | 'day'
+  | 'week'
+  | 'month'
+  | 'year';

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "tsconfig/tsconfig.base.json",
   "compilerOptions": {
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "baseUrl": ".",
+    "paths": {
+      "@seedcompany/common": ["./src"]
+    },
   },
   "include": ["src"],
   "exclude": ["dist", "node_modules"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4164,6 +4164,14 @@ __metadata:
 "@seedcompany/common@workspace:^, @seedcompany/common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@seedcompany/common@workspace:packages/common"
+  dependencies:
+    "@types/luxon": ^3.2.0
+    luxon: ^3.3.0
+  peerDependencies:
+    luxon: ^3.3.0
+  peerDependenciesMeta:
+    luxon:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -4563,6 +4571,13 @@ __metadata:
   version: 4.0.2
   resolution: "@types/long@npm:4.0.2"
   checksum: d16cde7240d834cf44ba1eaec49e78ae3180e724cd667052b194a372f350d024cba8dd3f37b0864931683dab09ca935d52f0c4c1687178af5ada9fc85b0635f4
+  languageName: node
+  linkType: hard
+
+"@types/luxon@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@types/luxon@npm:3.2.0"
+  checksum: 051bfbf841c6ce98728df6538342ce4aaddfcf0ec6e8b473e0195dcfc3ba6b1fe4b3ce17f2ba6d25344f41cb70032c1debe96da9e384e5f6e639665c1e6d368c
   languageName: node
   linkType: hard
 
@@ -10856,6 +10871,13 @@ __metadata:
   version: 7.14.1
   resolution: "lru-cache@npm:7.14.1"
   checksum: d72c6713c6a6d86836a7a6523b3f1ac6764768cca47ec99341c3e76db06aacd4764620e5e2cda719a36848785a52a70e531822dc2b33fb071fa709683746c104
+  languageName: node
+  linkType: hard
+
+"luxon@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "luxon@npm:3.3.0"
+  checksum: 50cf17a0dc155c3dcacbeae8c0b7e80db425e0ba97b9cbdf12a7fc142d841ff1ab1560919f033af46240ed44e2f70c49f76e3422524c7fc8bb8d81ca47c66187
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Parse Human duration strings
Added a human duration parser helper to convert strings like below into objects form. 
https://github.com/SeedCompany/libs/blob/63544767401d14a19e9ab4e6439b8620fa4c1d26/packages/common/src/temporal/parseHumanToDurationLike.test.ts#L20-L30
No temporal math included, just a string parser. The idea is to be useful for developers in certain siutations. Env var options is one example.

# Optional luxon duration augmentation
Optionally if `luxon` is used, we can augment it.
```tsx
import { Duration } from 'luxon';
import '@seedcompany/common/temporal/luxon';

Duration.from('5 secs'); 		// Human -> Duration
Duration.from('PT5S');			// ISO -> Duration
Duration.from({ seconds: 5 });	// object-like -> Duration
```
We also update our delay function to accept `DurationIn` types
```tsx
import { delay } from 'luxon';
import '@seedcompany/common/temporal/luxon';

delay('5 secs');
delay('PT5S');
delay({ seconds: 5 });
```

This luxon import only needs be done once per execution.