### PR TITLE
feat(cache): init lib

### DIFF
--- a/packages/cache/.eslintrc.cjs
+++ b/packages/cache/.eslintrc.cjs
@@ -1,0 +1,9 @@
+/** @type {import('@typescript-eslint/utils').TSESLint.Linter.Config} */
+const config = {
+  root: true,
+  plugins: ['@seedcompany'],
+  extends: ['plugin:@seedcompany/nestjs'],
+};
+
+// eslint-disable-next-line no-undef
+module.exports = config;

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -1,0 +1,218 @@
+# Yet another cache library for NestJS
+
+This is for data that will be shared across multiple processes.
+Thus, the keys are strings and the values are serializable.
+
+The goals of this library are:
+- Provide a nice interface for usage in Nestjs classes
+- Integrate easily with the existing Nestjs ecosystem
+- Leverage existing npm ecosystem for storage implementations
+
+# Setup
+
+Import the module in your app.
+```ts
+CacheModule.registerAsync({
+  inject: [/* config */],
+  useFactory: (/* config */): CacheModuleOptions => ({
+    store: // create store implementation from config
+  }),
+})
+```
+
+# Usage
+
+## Decorators
+
+```ts
+@Injectable()
+class Service {
+
+  @Cache({
+    key: 'foo-bar',
+    ttl: { minutes: 5 },
+  })
+  async fooBar() {
+    // ...
+  }
+
+}
+```
+
+However, you will probably need to cache based on the args given, so:
+```ts
+@Injectable()
+class Service {
+
+  @Cache((id: string, year: number) => ({
+    key: `foo-bar:${id}-${year}`,
+    ttl: { minutes: 5 },
+  }))
+  async fooBar(id: string, year: number) {
+    // ...
+  }
+
+}
+```
+
+## Service
+
+The task you always most always want to do is skip expensive calculation if possible.
+So the most useful method is `getOrCalculate`, which saves you the boilerplate for this logic.
+
+```ts
+declare const cache: CacheService; // injected somewhere
+
+const result = await cache.getOrCalculate({
+  key: `fooBar:${id}`,
+  calculate: async () => {
+    // do expensive calculation
+  },
+  ttl: { hour: 1 },
+});
+```
+
+Naive functionality exists as well:
+```ts
+await cache.get('foo');
+await cache.set('foo', 'bar');
+await cache.delete('foo');
+```
+
+## Namespaces
+
+A common use case is to namespace your cache keys, to help segment your cache store.
+There's a `namespace` method which returns a modified cache service with the given prefix.
+```ts
+const usersCache = cache.namespace('users:');
+```
+Note that chaining these will stack the prefixes, not override them.
+```ts
+cache.namespace('foo:').namespace('bar:').get('baz'); // foo:bar:baz
+```
+
+## CacheItem
+
+A wrapper is provided around a single cache keys as well.
+This could help prevent having to store another variable for a computed key, or allow it to be passed around.
+```ts
+const cached = cache.item('1234');
+const value = cached.getOrCalculate(async () => {
+  // do expensive calculation
+});
+handleInvalidation(cached);
+function handleInvalidation(cached: CacheItem) {
+  if (isStale) {
+    cached.delete();
+  }
+}
+```
+
+# Stores
+
+Stores are the actual storage implementations the `CacheService` is backed by.
+
+We provide stores for `ioredis`, `keyv`, `lru-cache`.
+This should cover most use cases, but you can also implement your own.
+
+## LRU / In Memory
+```ts
+import { LruStore } from '@seedcompany/cache/store/lru';
+
+CacheModule.register({
+  store: new LruStore({
+    // options
+  })
+})
+```
+
+## Redis
+```ts
+import { RedisStore } from '@seedcompany/cache/store/redis';
+import Redis from 'ioredis';
+
+CacheModule.register({
+  store: new RedisStore(
+    new Redis('redis://localhost:6379')
+  )
+})
+```
+
+## Keyv
+```ts
+import { KeyvStore } from '@seedcompany/cache/store/keyv';
+import Keyv from 'keyv';
+
+CacheModule.register({
+  store: new KeyvStore(
+    new Keyv()
+  )
+})
+```
+
+## Chaining Multiple Stores
+
+Multiple stores can be chained together with the `ChainStore`.
+This could provide faster in memory cache falling back to a shared network cache.
+
+```ts
+import { ChainStore } from '@seedcompany/cache/store/chain';
+
+CacheModule.register({
+  store: new ChainStore([
+    new LruStore({ max: 100 }),
+    new RedisStore(),
+  ])
+})
+```
+
+# Adapters
+
+We provide a few adapters to help integrate with other libraries.
+
+## NestJS (HTTP?) Cache
+
+Here's how to set up the NestJS cache module to be based on this one.
+
+```ts
+import { CacheModule as NestHttpCacheModule } from '@nestjs/common';
+import { CacheModule, CacheService } from '@seedcompany/cache';
+
+NestHttpCacheModule.registerAsync({
+  imports: [CacheModule],
+  inject: [CacheService],
+  useFactory: (cache: CacheService): CacheModuleOptions => ({
+    store: cache.namespace('http:').adaptTo.cacheManager(),
+  }),
+});
+```
+Continue on with the NestJS docs:
+https://docs.nestjs.com/techniques/caching#interacting-with-the-cache-store
+
+## Apollo Cache
+
+Here's how to set up the Apollo cache to be based on this one.
+
+```ts
+GraphQLModule.forRootAsync<ApolloDriverConfig>({
+  driver: ApolloDriver,
+  imports: [CacheModule],
+  inject: [CacheService],
+  useFactory: (cache: CacheService) => ({
+    cache: cache.namespace('apollo:').adaptTo.apollo(),
+  }),
+});
+```
+
+## Keyv Cache
+
+Keyv cache is a very popular cache library.
+Here's how to adapt our cache to its interface.
+
+```ts
+declare const cache: CacheService;
+
+const kv = new Keyv({
+  store: cache.adaptTo.keyv(),
+});
+```

--- a/packages/cache/jest.config.ts
+++ b/packages/cache/jest.config.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/no-default-export
+export { default } from '../../jest.config';

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seedcompany/cache",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "NestJS library wrapper for external caching",
   "license": "MIT",
   "engines": {
@@ -9,20 +9,42 @@
   "dependencies": {
     "@nestjs/common": "^9",
     "@nestjs/core": "^9",
-    "@seedcompany/common": "workspace:^"
+    "@seedcompany/common": ">0.3 <1",
+    "@types/luxon": "^3.2.0",
+    "luxon": "^3.3.0",
+    "type-fest": "^3.6.1"
   },
   "peerDependencies": {
     "@nestjs/common": "^9",
     "@nestjs/core": "^9",
+    "ioredis": "^5",
+    "keyv": "^4",
+    "lru-cache": "^8",
     "reflect-metadata": "^0.1.12"
   },
+  "peerDependenciesMeta": {
+    "ioredis": {
+      "optional": true
+    },
+    "keyv": {
+      "optional": true
+    },
+    "lru-cache": {
+      "optional": true
+    }
+  },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
+    "build": "tsup",
     "typecheck": "tsc",
     "test": "jest"
   },
   "devDependencies": {
+    "@apollo/utils.keyvaluecache": "^2.1.0",
     "@nestjs/testing": "^9",
+    "cache-manager": "^5.2.0",
+    "ioredis": "^5.3.1",
+    "keyv": "^4.5.2",
+    "lru-cache": "^8.0.4",
     "rxjs": "^7.5.7"
   },
   "repository": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@seedcompany/cache",
+  "version": "0.1.0",
+  "description": "NestJS library wrapper for external caching",
+  "license": "MIT",
+  "engines": {
+    "node": ">=16"
+  },
+  "dependencies": {
+    "@nestjs/common": "^9",
+    "@nestjs/core": "^9",
+    "@seedcompany/common": "workspace:^"
+  },
+  "peerDependencies": {
+    "@nestjs/common": "^9",
+    "@nestjs/core": "^9",
+    "reflect-metadata": "^0.1.12"
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
+    "typecheck": "tsc",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@nestjs/testing": "^9",
+    "rxjs": "^7.5.7"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seedcompany/libs.git",
+    "directory": "packages/cache"
+  },
+  "bugs": {
+    "url": "https://github.com/seedcompany/libs/issues"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  }
+}

--- a/packages/cache/project.yaml
+++ b/packages/cache/project.yaml
@@ -1,0 +1,20 @@
+implicitDependencies:
+  - common
+
+targets:
+  lint: {}
+
+  version:
+    options:
+      commitMessageFormat: >
+        release(${projectName}): ${version}
+      postTargets:
+        - cache:publish-npm
+        - cache:publish-github
+  publish-npm:
+    options:
+      distFolderPath: packages/cache
+  publish-github:
+    options:
+      tag: ${tag}
+      notesStartTag: ${previousTag}

--- a/packages/cache/src/adapters/adapters.facade.ts
+++ b/packages/cache/src/adapters/adapters.facade.ts
@@ -1,0 +1,23 @@
+import { CacheService, ItemOptions } from '../cache.service';
+import { ApolloCacheAdapter } from './apollo';
+import { CacheManagerAdapter } from './cache-manager';
+import { KeyvAdapter } from './keyv';
+
+/**
+ * A helper class to adapt our CacheService to other cache shapes.
+ */
+export class CacheAdapters {
+  constructor(private readonly cache: CacheService) {}
+
+  apollo(options: ItemOptions = {}) {
+    return new ApolloCacheAdapter(this.cache, options);
+  }
+
+  cacheManager(options: ItemOptions = {}) {
+    return new CacheManagerAdapter(this.cache, options);
+  }
+
+  keyv<Value>(options: ItemOptions = {}) {
+    return new KeyvAdapter<Value>(this.cache, options);
+  }
+}

--- a/packages/cache/src/adapters/apollo.ts
+++ b/packages/cache/src/adapters/apollo.ts
@@ -1,0 +1,29 @@
+import type {
+  KeyValueCache,
+  KeyValueCacheSetOptions,
+} from '@apollo/utils.keyvaluecache';
+import { CacheService, ItemOptions } from '../cache.service';
+
+/**
+ * A drop-in adapter for Apollo Server's cache to use our CacheService.
+ */
+export class ApolloCacheAdapter implements KeyValueCache {
+  constructor(
+    private readonly cache: CacheService,
+    private readonly options: ItemOptions = {},
+  ) {}
+
+  async get(key: string): Promise<string | undefined> {
+    return await this.cache.get(key, this.options);
+  }
+
+  async set(key: string, value: string, options?: KeyValueCacheSetOptions) {
+    await this.cache.set(key, value, {
+      ttl: options?.ttl != null ? { seconds: options.ttl } : this.options.ttl,
+    });
+  }
+
+  async delete(key: string) {
+    await this.cache.delete(key);
+  }
+}

--- a/packages/cache/src/adapters/cache-manager.ts
+++ b/packages/cache/src/adapters/cache-manager.ts
@@ -1,0 +1,73 @@
+import type {
+  CacheStoreSetOptions,
+  CacheStore as NestCacheStore,
+} from '@nestjs/common';
+import { DurationIn } from '@seedcompany/common/temporal/luxon';
+import type { Store as CacheManagerStore } from 'cache-manager';
+import { CacheService, ItemOptions } from '../cache.service';
+
+// noinspection SpellCheckingInspection
+
+/**
+ * A store for `cache-manager` which is also what `@nestjs/common` uses.
+ */
+export class CacheManagerAdapter implements CacheManagerStore, NestCacheStore {
+  constructor(
+    private readonly cache: CacheService,
+    private readonly options: ItemOptions = {},
+  ) {}
+
+  async get<T>(key: string): Promise<T | undefined> {
+    return await this.cache.get<T>(key, {
+      refreshTtlOnGet: this.options.refreshTtlOnGet,
+    });
+  }
+
+  async set<T>(
+    key: string,
+    value: T,
+    options?: CacheStoreSetOptions<T> | number,
+  ) {
+    const { ttl: ttlIn } =
+      typeof options === 'number' ? { ttl: options } : options ?? {};
+    const ttl =
+      ttlIn == null
+        ? this.options.ttl
+        : typeof ttlIn === 'number'
+        ? ttlIn
+        : ttlIn(value);
+    await this.cache.set(key, value, { ttl });
+  }
+
+  async del(key: string) {
+    await this.cache.delete(key);
+  }
+
+  async ttl(key: string) {
+    const remaining = await this.cache.remainingTtl(key);
+    return remaining.toMillis();
+  }
+
+  async reset() {
+    // nope
+  }
+
+  async keys() {
+    return [];
+  }
+
+  async mdel(...keys: string[]) {
+    await Promise.all(keys.map((key) => this.cache.delete(key)));
+  }
+
+  async mget(...keys: string[]) {
+    return await Promise.all(keys.map((key) => this.cache.get(key)));
+  }
+
+  async mset(pairs: Array<[string, unknown]>, ttl?: DurationIn) {
+    ttl ??= this.options.ttl;
+    await Promise.all(
+      pairs.map(([key, value]) => this.cache.set(key, value, { ttl })),
+    );
+  }
+}

--- a/packages/cache/src/adapters/keyv.ts
+++ b/packages/cache/src/adapters/keyv.ts
@@ -1,0 +1,31 @@
+import { DurationIn } from '@seedcompany/common/temporal/luxon';
+import type { Store as KeyvStore } from 'keyv';
+import { CacheService, ItemOptions } from '../cache.service';
+
+/**
+ * A `keyv` store backed by our CacheService.
+ */
+export class KeyvAdapter<Value> implements KeyvStore<Value> {
+  constructor(
+    private readonly cache: CacheService,
+    private readonly options: ItemOptions = {},
+  ) {}
+
+  async get(key: string): Promise<Value | undefined> {
+    return await this.cache.get(key, this.options);
+  }
+
+  async set(key: string, value: Value, ttl?: DurationIn) {
+    ttl ??= this.options.ttl;
+    await this.cache.set(key, value, { ttl });
+  }
+
+  async delete(key: string) {
+    await this.cache.delete(key);
+    return true;
+  }
+
+  async clear() {
+    // nope
+  }
+}

--- a/packages/cache/src/cache.decorator.ts
+++ b/packages/cache/src/cache.decorator.ts
@@ -1,0 +1,60 @@
+import { Inject } from '@nestjs/common';
+import { Except } from 'type-fest';
+import { CacheableCalculationOptions, CacheService } from './cache.service';
+
+const CacheKey = Symbol('CacheService');
+
+type CacheOptions = Except<CacheableCalculationOptions<unknown>, 'calculate'>;
+type CacheOptionsOrFn<Args extends any[]> =
+  | CacheOptions
+  | ((...args: Args) => CacheOptions);
+
+/**
+ * Cache result of this method.
+ *
+ * This is just a shortcut for calling {@link CacheService.getOrCalculate}.
+ *
+ * @example
+ * ```
+ * @Cache({ key: 'foo-bar', ttl: { minutes: 5 } })
+ * async fooBar() { ... }
+ * ```
+ *
+ * @example
+ * However, you will probably need to cache based on the args given, so:
+ * ```
+ * @Cache((id: string, year: number) => ({
+ *   key: `foo-bar:${id}-${year}`,
+ *   ttl: { minutes: 5 },
+ * }))
+ * async fooBar(id: string, year: number) { ... }
+ *
+ * Yes unfortunately you have to type the args twice.
+ * ```
+ */
+export const Cache =
+  <Args extends any[]>(options: CacheOptionsOrFn<Args>) =>
+  <Result>(
+    target: any,
+    methodName: string | symbol,
+    descriptor: TypedPropertyDescriptor<
+      (this: { [CacheKey]: CacheService }, ...args: Args) => Promise<Result>
+    >,
+  ) => {
+    // Use property-based injection to get access to the Cache object at a known location.
+    if (target[CacheKey] === undefined) {
+      Inject(CacheService)(target, CacheKey);
+      // Ensure prop injection is only done once, by having
+      // subsequent methods in this class will skip this if statement.
+      target[CacheKey] = null;
+    }
+
+    // Wrap the method
+    const origMethod = descriptor.value!;
+    descriptor.value = async function (...args) {
+      return await this[CacheKey].getOrCalculate({
+        ...(typeof options === 'function' ? options(...args) : options),
+        calculate: () => origMethod.apply(this, args),
+      });
+    };
+  };

--- a/packages/cache/src/cache.module-builder.ts
+++ b/packages/cache/src/cache.module-builder.ts
@@ -1,0 +1,16 @@
+import { ConfigurableModuleBuilder } from '@nestjs/common';
+import { CacheStore } from './stores';
+
+export interface CacheModuleOptions {
+  store: CacheStore;
+}
+
+export const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN } =
+  new ConfigurableModuleBuilder<CacheModuleOptions>({
+    moduleName: 'Cache',
+  })
+    .setExtras({ global: false }, (definition, extras) => ({
+      ...definition,
+      global: extras.global,
+    }))
+    .build();

--- a/packages/cache/src/cache.module.test.ts
+++ b/packages/cache/src/cache.module.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { CacheModule } from './cache.module';
+import { CacheService } from './cache.service';
+import { LruStore } from './stores/lru';
+
+describe('CacheModule', () => {
+  it('should be creatable with register()', async () => {
+    const module = await Test.createTestingModule({
+      imports: [
+        CacheModule.register({
+          store: new LruStore(),
+        }),
+      ],
+    }).compile();
+    const app = module.createNestApplication();
+    await app.init();
+
+    const cache = app.get(CacheService);
+    expect(cache).toBeInstanceOf(CacheService);
+
+    await cache.set('foo', 'bar');
+    expect(await cache.get('foo')).toBe('bar');
+
+    await app.close();
+  });
+});

--- a/packages/cache/src/cache.module.ts
+++ b/packages/cache/src/cache.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import {
+  CacheModuleOptions,
+  ConfigurableModuleClass,
+  MODULE_OPTIONS_TOKEN,
+} from './cache.module-builder';
+import { CacheService } from './cache.service';
+import { CacheStore } from './stores';
+
+@Module({
+  providers: [
+    CacheService,
+    {
+      provide: CacheStore,
+      inject: [MODULE_OPTIONS_TOKEN],
+      useFactory: (options: CacheModuleOptions) => options.store,
+    },
+  ],
+  exports: [CacheService],
+})
+export class CacheModule extends ConfigurableModuleClass {}

--- a/packages/cache/src/cache.service.ts
+++ b/packages/cache/src/cache.service.ts
@@ -1,0 +1,122 @@
+import { Injectable } from '@nestjs/common';
+import type { DurationIn } from '@seedcompany/common/temporal/luxon';
+import { Duration } from 'luxon';
+import { Promisable } from 'type-fest';
+import { CacheAdapters } from './adapters/adapters.facade';
+import { NamespaceStore } from './stores/namespace';
+import {
+  CacheStore,
+  CacheStoreItemOptions as StoreItemOptions,
+} from './stores/store.interface';
+import '@seedcompany/common/temporal/luxon';
+
+@Injectable()
+export class CacheService {
+  constructor(private readonly store: CacheStore) {}
+
+  get adaptTo() {
+    return new CacheAdapters(this);
+  }
+
+  namespace(subSpace: string) {
+    if (!subSpace) {
+      return this;
+    }
+    return new CacheService(new NamespaceStore(this.store, subSpace));
+  }
+
+  item<T>(key: string, options?: ItemOptions): CacheItem<T> {
+    return new CacheItem<T>(key, this, options);
+  }
+
+  async get<T>(key: string, options: ItemOptions = {}): Promise<T | undefined> {
+    return await this.store.get<T>(key, this.resolveOptions(options));
+  }
+
+  async set(key: string, value: unknown, options: ItemOptions = {}) {
+    await this.store.set(key, value, this.resolveOptions(options));
+  }
+
+  private resolveOptions(options: ItemOptions): StoreItemOptions {
+    const { ttl: rawTtl, ...rest } = options;
+    let ttl = rawTtl ? Duration.from(rawTtl) : undefined;
+    const ttlMs = ttl?.toMillis();
+    // Treat 0 as infinite
+    ttl = ttlMs === 0 || ttlMs === Infinity ? undefined : ttl;
+    return { ttl, ...rest };
+  }
+
+  async delete(key: string) {
+    await this.store.delete(key);
+  }
+
+  async remainingTtl(key: string) {
+    const milliseconds = await this.store.remainingTtl(key);
+    return Duration.from(milliseconds);
+  }
+
+  async getOrCalculate<T>(options: CacheableCalculationOptions<T>): Promise<T> {
+    const { key, calculate, ...cacheOptions } = options;
+    const prev = await this.get<T>(key);
+    if (prev) {
+      return prev;
+    }
+    const now = await calculate();
+    await this.set(key, now, cacheOptions);
+    return now;
+  }
+}
+
+export interface ItemOptions extends Pick<StoreItemOptions, 'refreshTtlOnGet'> {
+  /**
+   * Time to live - duration that an item is cached before it is deleted.
+   */
+  ttl?: DurationIn;
+}
+
+export interface CacheableCalculationOptions<T> extends ItemOptions {
+  key: string;
+
+  calculate: () => Promisable<T>;
+}
+
+export class CacheItem<T> {
+  /**
+   * @internal
+   */
+  constructor(
+    readonly key: string,
+    private readonly service: CacheService,
+    private readonly options: ItemOptions = {},
+  ) {}
+
+  async get(optionsOverride?: Partial<ItemOptions>): Promise<T | undefined> {
+    return await this.service.get<T>(this.key, {
+      ...this.options,
+      ...optionsOverride,
+    });
+  }
+
+  async set(value: T, optionsOverride?: Partial<ItemOptions>) {
+    await this.service.set(this.key, value, {
+      ...this.options,
+      ...optionsOverride,
+    });
+  }
+
+  async delete() {
+    await this.service.delete(this.key);
+  }
+
+  async getOrCalculate(
+    options:
+      | Omit<CacheableCalculationOptions<T>, 'key'>
+      | (() => Promisable<T>),
+  ): Promise<T> {
+    return await this.service.getOrCalculate({
+      ...this.options,
+      ...(typeof options === 'function' ? { calculate: options } : options),
+      key: this.key,
+    });
+  }
+}

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -1,0 +1,5 @@
+export * from './cache.service';
+export * from './cache.decorator';
+export * from './cache.module';
+export type { CacheModuleOptions } from './cache.module-builder';
+export * from './adapters/adapters.facade';

--- a/packages/cache/src/stores/chain.ts
+++ b/packages/cache/src/stores/chain.ts
@@ -1,0 +1,38 @@
+import { CacheStore, CacheStoreItemOptions } from './store.interface';
+
+export class ChainStore extends CacheStore {
+  constructor(readonly stores: readonly CacheStore[]) {
+    super();
+  }
+
+  async get<T>(key: string, options: CacheStoreItemOptions) {
+    for (const store of this.stores) {
+      const value = await store.get<T>(key, options);
+      if (value !== undefined) {
+        return value;
+      }
+    }
+    return undefined;
+  }
+
+  async set<T>(key: string, value: T, options: CacheStoreItemOptions) {
+    await Promise.all(
+      this.stores.map((store) => store.set(key, value, options)),
+    );
+  }
+
+  async delete(key: string) {
+    await Promise.all(this.stores.map((store) => store.delete(key)));
+  }
+
+  async remainingTtl(key: string) {
+    const ttls = await Promise.all(
+      this.stores.map((store) => store.remainingTtl(key)),
+    );
+    const cleaned = ttls.filter(isFinite);
+    if (cleaned.length === 0) {
+      return Infinity;
+    }
+    return Math.max(...cleaned);
+  }
+}

--- a/packages/cache/src/stores/index.ts
+++ b/packages/cache/src/stores/index.ts
@@ -1,0 +1,1 @@
+export * from './store.interface';

--- a/packages/cache/src/stores/keyv.ts
+++ b/packages/cache/src/stores/keyv.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import type Keyv from 'keyv';
+import { CacheStore, CacheStoreItemOptions } from './store.interface';
+
+@Injectable()
+export class KeyvStore extends CacheStore {
+  constructor(private readonly keyv: Keyv) {
+    super();
+  }
+
+  async get(key: string, options: CacheStoreItemOptions) {
+    const val = await this.keyv.get(key);
+    if (options.refreshTtlOnGet && options.ttl) {
+      void this.keyv.set(key, val, options.ttl.toMillis());
+    }
+    return val;
+  }
+
+  async remainingTtl(_key: string) {
+    return Infinity;
+  }
+
+  async set<T>(key: string, value: T, options: CacheStoreItemOptions) {
+    await this.keyv.set(key, value, options.ttl?.toMillis());
+  }
+
+  async delete(key: string) {
+    await this.keyv.delete(key);
+  }
+}

--- a/packages/cache/src/stores/lru.ts
+++ b/packages/cache/src/stores/lru.ts
@@ -1,0 +1,48 @@
+import LRUCache from 'lru-cache';
+import { CacheStore, CacheStoreItemOptions } from './store.interface';
+
+export class LruStore extends CacheStore {
+  private readonly cache: LRUCache<string, any>;
+
+  constructor(options?: LRUCache.Options<string, any, unknown>) {
+    super();
+    this.cache = new LRUCache({
+      sizeCalculation,
+      maxSize: 2 ** 20 * 30,
+      ...options,
+    });
+  }
+
+  async get<T>(
+    key: string,
+    options: CacheStoreItemOptions,
+  ): Promise<T | undefined> {
+    return this.cache.get(key, {
+      updateAgeOnGet: options.refreshTtlOnGet,
+    }) as T | undefined;
+  }
+
+  async remainingTtl(key: string): Promise<number> {
+    return this.cache.getRemainingTTL(key);
+  }
+
+  async set<T>(key: string, value: T, options: CacheStoreItemOptions) {
+    this.cache.set(key, value, {
+      ttl: options.ttl?.toMillis(),
+    });
+  }
+
+  async delete(key: string) {
+    this.cache.delete(key);
+  }
+}
+
+const sizeCalculation = (item: unknown) => {
+  if (typeof item === 'string') {
+    return item.length;
+  }
+  if (typeof item === 'object') {
+    return Buffer.byteLength(JSON.stringify(item), 'utf8');
+  }
+  return 1;
+};

--- a/packages/cache/src/stores/namespace.ts
+++ b/packages/cache/src/stores/namespace.ts
@@ -1,0 +1,20 @@
+import { CacheStore, CacheStoreItemOptions } from './store.interface';
+
+export class NamespaceStore extends CacheStore {
+  constructor(readonly store: CacheStore, readonly namespace: string) {
+    super();
+  }
+
+  get<T>(key: string, options: CacheStoreItemOptions) {
+    return this.store.get<T>(this.namespace + key, options);
+  }
+  async set<T>(key: string, value: T, options: CacheStoreItemOptions) {
+    await this.store.set(this.namespace + key, value, options);
+  }
+  async delete(key: string) {
+    await this.store.delete(this.namespace + key);
+  }
+  async remainingTtl(key: string) {
+    return await this.store.remainingTtl(this.namespace + key);
+  }
+}

--- a/packages/cache/src/stores/redis.ts
+++ b/packages/cache/src/stores/redis.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import Redis from 'ioredis';
+import { CacheStore, CacheStoreItemOptions } from './store.interface';
+
+@Injectable()
+export class RedisStore extends CacheStore {
+  constructor(private readonly redis: Redis) {
+    super();
+  }
+
+  async get<T>(key: string, options: CacheStoreItemOptions) {
+    const val = await this.redis.get(key);
+    if (options.refreshTtlOnGet && options.ttl) {
+      void this.redis.pexpire(key, options.ttl.toMillis());
+    }
+    if (val == null) {
+      return undefined;
+    }
+    return JSON.parse(val) as T;
+  }
+
+  async remainingTtl(key: string) {
+    const ttl = await this.redis.pttl(key);
+    return ttl === -2 ? 0 : ttl === -1 ? Infinity : ttl;
+  }
+
+  async set<T>(key: string, value: T, options: CacheStoreItemOptions) {
+    const encoded = JSON.stringify(value);
+    if (options.ttl) {
+      await this.redis.set(key, encoded, 'PX', options.ttl.toMillis());
+    } else {
+      await this.redis.set(key, encoded);
+    }
+  }
+
+  async delete(key: string) {
+    await this.redis.del(key);
+  }
+}

--- a/packages/cache/src/stores/store.interface.ts
+++ b/packages/cache/src/stores/store.interface.ts
@@ -1,0 +1,27 @@
+import { Duration } from 'luxon';
+
+export abstract class CacheStore {
+  abstract get<T>(
+    key: string,
+    options: CacheStoreItemOptions,
+  ): Promise<T | undefined>;
+  abstract set<T>(
+    key: string,
+    value: T,
+    options: CacheStoreItemOptions,
+  ): Promise<void>;
+  abstract delete(key: string): Promise<void>;
+  abstract remainingTtl(key: string): Promise<Milliseconds>;
+}
+
+type Milliseconds = number;
+
+export interface CacheStoreItemOptions {
+  /**
+   * Time to live - duration that an item is cached before it is deleted.
+   */
+  ttl?: Duration;
+
+  /** Refresh TTL on cache hit, so that the item stays fresh longer */
+  refreshTtlOnGet?: boolean;
+}

--- a/packages/cache/tsconfig.json
+++ b/packages/cache/tsconfig.json
@@ -1,5 +1,12 @@
 {
   "extends": "tsconfig/tsconfig.nestjs.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@seedcompany/common": ["../common/src"],
+      "@seedcompany/common/*": ["../common/src/*"],
+    },
+  },
   "include": ["src"],
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/cache/tsconfig.json
+++ b/packages/cache/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "tsconfig/tsconfig.nestjs.json",
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/cache/tsup.config.ts
+++ b/packages/cache/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export const tsup = defineConfig({
+  entry: ['src', '!src/**/*.test.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,10 +121,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@apollo/utils.keyvaluecache@npm:^2.1.0":
+  version: 2.1.1
+  resolution: "@apollo/utils.keyvaluecache@npm:2.1.1"
+  dependencies:
+    "@apollo/utils.logger": ^2.0.1
+    lru-cache: ^7.14.1
+  checksum: c49b297a30ef02336d605a9fd342443eb9ea7ea36b9331a2cd5f8cb1613656e5d06b4445ca09784b18c12b417bca17fe09d40e25196266e2a734da3200d27ea5
+  languageName: node
+  linkType: hard
+
 "@apollo/utils.logger@npm:^1.0.0":
   version: 1.0.1
   resolution: "@apollo/utils.logger@npm:1.0.1"
   checksum: 621bd80ce43a73f97342568b712fd46fee9041212d4c7264a63676e29d17ab292773c3c21b91f8a2dffb1fe7931ece3954886bd04e3100e1765c6d05e231e2a7
+  languageName: node
+  linkType: hard
+
+"@apollo/utils.logger@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@apollo/utils.logger@npm:2.0.1"
+  checksum: f975c81fcc7e54669b975031349f292930dc4cc3dd6bdc58bc7fe2159e0398a7d18b28860ee324c23722b005848e258094a143d20f6989fde5837379240b0066
   languageName: node
   linkType: hard
 
@@ -3008,6 +3025,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ioredis/commands@npm:^1.1.1":
+  version: 1.2.0
+  resolution: "@ioredis/commands@npm:1.2.0"
+  checksum: 9b20225ba36ef3e5caf69b3c0720597c3016cc9b1e157f519ea388f621dd9037177f84cfe7e25c4c32dad7dd90c70ff9123cd411f747e053cf292193c9c461e2
+  languageName: node
+  linkType: hard
+
 "@istanbuljs/load-nyc-config@npm:^1.0.0":
   version: 1.1.0
   resolution: "@istanbuljs/load-nyc-config@npm:1.1.0"
@@ -4139,7 +4163,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@seedcompany/common@>=0.3.0 <1.0.0, @seedcompany/common@workspace:packages/common":
+"@seedcompany/cache@workspace:packages/cache":
+  version: 0.0.0-use.local
+  resolution: "@seedcompany/cache@workspace:packages/cache"
+  dependencies:
+    "@apollo/utils.keyvaluecache": ^2.1.0
+    "@nestjs/common": ^9
+    "@nestjs/core": ^9
+    "@nestjs/testing": ^9
+    "@seedcompany/common": ">0.3 <1"
+    "@types/luxon": ^3.2.0
+    cache-manager: ^5.2.0
+    ioredis: ^5.3.1
+    keyv: ^4.5.2
+    lru-cache: ^8.0.4
+    luxon: ^3.3.0
+    rxjs: ^7.5.7
+    type-fest: ^3.6.1
+  peerDependencies:
+    "@nestjs/common": ^9
+    "@nestjs/core": ^9
+    ioredis: ^5
+    keyv: ^4
+    lru-cache: ^8
+    reflect-metadata: ^0.1.12
+  peerDependenciesMeta:
+    ioredis:
+      optional: true
+    keyv:
+      optional: true
+    lru-cache:
+      optional: true
+  languageName: unknown
+  linkType: soft
+
+"@seedcompany/common@>0.3 <1, @seedcompany/common@>=0.3.0 <1.0.0, @seedcompany/common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@seedcompany/common@workspace:packages/common"
   dependencies:
@@ -5993,6 +6051,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cache-manager@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "cache-manager@npm:5.2.0"
+  dependencies:
+    lodash.clonedeep: ^4.5.0
+    lru-cache: ~7.18.3
+  checksum: 1f1ec19c902c01817af782c2fc3ba96705325794e20fc4865ec9382eb91c1cee76dc560a63f774cb54b85067142134b5338183c4cc7f465375fb063ce62b84ac
+  languageName: node
+  linkType: hard
+
 "call-bind@npm:^1.0.0, call-bind@npm:^1.0.2":
   version: 1.0.2
   resolution: "call-bind@npm:1.0.2"
@@ -6299,6 +6367,13 @@ __metadata:
   version: 1.0.4
   resolution: "clone@npm:1.0.4"
   checksum: d06418b7335897209e77bdd430d04f882189582e67bd1f75a04565f3f07f5b3f119a9d670c943b6697d0afb100f03b866b3b8a1f91d4d02d72c4ecf2bb64b5dd
+  languageName: node
+  linkType: hard
+
+"cluster-key-slot@npm:^1.1.0":
+  version: 1.1.2
+  resolution: "cluster-key-slot@npm:1.1.2"
+  checksum: be0ad2d262502adc998597e83f9ded1b80f827f0452127c5a37b22dfca36bab8edf393f7b25bb626006fb9fb2436106939ede6d2d6ecf4229b96a47f27edd681
   languageName: node
   linkType: hard
 
@@ -7062,6 +7137,13 @@ __metadata:
   version: 1.0.0
   resolution: "delegates@npm:1.0.0"
   checksum: a51744d9b53c164ba9c0492471a1a2ffa0b6727451bdc89e31627fdf4adda9d51277cfcbfb20f0a6f08ccb3c436f341df3e92631a3440226d93a8971724771fd
+  languageName: node
+  linkType: hard
+
+"denque@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "denque@npm:2.1.0"
+  checksum: 1d4ae1d05e59ac3a3481e7b478293f4b4c813819342273f3d5b826c7ffa9753c520919ba264f377e09108d24ec6cf0ec0ac729a5686cbb8f32d797126c5dae74
   languageName: node
   linkType: hard
 
@@ -9155,6 +9237,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ioredis@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "ioredis@npm:5.3.1"
+  dependencies:
+    "@ioredis/commands": ^1.1.1
+    cluster-key-slot: ^1.1.0
+    debug: ^4.3.4
+    denque: ^2.1.0
+    lodash.defaults: ^4.2.0
+    lodash.isarguments: ^3.1.0
+    redis-errors: ^1.2.0
+    redis-parser: ^3.0.0
+    standard-as-callback: ^2.1.0
+  checksum: 6c98cb8f8772ad4bb2b6b7a0a224e4a63f4759f9a28e84205f18788552f08221d51f391c10892dca01a1b10b2804d0a7e6082b0b7decd65538a5fb6b0f4f1f82
+  languageName: node
+  linkType: hard
+
 "ip@npm:^2.0.0":
   version: 2.0.0
   resolution: "ip@npm:2.0.0"
@@ -10510,6 +10609,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-buffer@npm:3.0.1":
+  version: 3.0.1
+  resolution: "json-buffer@npm:3.0.1"
+  checksum: 9026b03edc2847eefa2e37646c579300a1f3a4586cfb62bf857832b60c852042d0d6ae55d1afb8926163fa54c2b01d83ae24705f34990348bdac6273a29d4581
+  languageName: node
+  linkType: hard
+
 "json-parse-better-errors@npm:^1.0.1":
   version: 1.0.2
   resolution: "json-parse-better-errors@npm:1.0.2"
@@ -10621,6 +10727,15 @@ __metadata:
   bin:
     juice: bin/juice
   checksum: fb7bd29b2482a518cf9f28343c713f1133a78303a0b41f483c856d35b0d346cd6b7d7015639f49eca722fba5ccb997b6611878918525f032f2a47a099a1b756c
+  languageName: node
+  linkType: hard
+
+"keyv@npm:^4.5.2":
+  version: 4.5.2
+  resolution: "keyv@npm:4.5.2"
+  dependencies:
+    json-buffer: 3.0.1
+  checksum: 13ad58303acd2261c0d4831b4658451603fd159e61daea2121fcb15feb623e75ee328cded0572da9ca76b7b3ceaf8e614f1806c6b3af5db73c9c35a345259651
   languageName: node
   linkType: hard
 
@@ -10790,10 +10905,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.clonedeep@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.clonedeep@npm:4.5.0"
+  checksum: 92c46f094b064e876a23c97f57f81fbffd5d760bf2d8a1c61d85db6d1e488c66b0384c943abee4f6af7debf5ad4e4282e74ff83177c9e63d8ff081a4837c3489
+  languageName: node
+  linkType: hard
+
 "lodash.debounce@npm:^4.0.8":
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
   checksum: a3f527d22c548f43ae31c861ada88b2637eb48ac6aa3eb56e82d44917971b8aa96fbb37aa60efea674dc4ee8c42074f90f7b1f772e9db375435f6c83a19b3bc6
+  languageName: node
+  linkType: hard
+
+"lodash.defaults@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "lodash.defaults@npm:4.2.0"
+  checksum: 84923258235592c8886e29de5491946ff8c2ae5c82a7ac5cddd2e3cb697e6fbdfbbb6efcca015795c86eec2bb953a5a2ee4016e3735a3f02720428a40efbb8f1
+  languageName: node
+  linkType: hard
+
+"lodash.isarguments@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "lodash.isarguments@npm:3.1.0"
+  checksum: ae1526f3eb5c61c77944b101b1f655f846ecbedcb9e6b073526eba6890dc0f13f09f72e11ffbf6540b602caee319af9ac363d6cdd6be41f4ee453436f04f13b5
   languageName: node
   linkType: hard
 
@@ -10984,10 +11120,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^7.7.1":
+"lru-cache@npm:^7.14.1, lru-cache@npm:^7.7.1, lru-cache@npm:~7.18.3":
   version: 7.18.3
   resolution: "lru-cache@npm:7.18.3"
   checksum: e550d772384709deea3f141af34b6d4fa392e2e418c1498c078de0ee63670f1f46f5eee746e8ef7e69e1c895af0d4224e62ee33e66a543a14763b0f2e74c1356
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^8.0.4":
+  version: 8.0.5
+  resolution: "lru-cache@npm:8.0.5"
+  checksum: 87d72196d8f46e8299c4ab576ed2ec8a07e3cbef517dc9874399c0b2470bd9bf62aacec3b67f84ed6d74aaa1ef31636d048edf996f76248fd17db72bfb631609
   languageName: node
   linkType: hard
 
@@ -12981,6 +13124,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redis-errors@npm:^1.0.0, redis-errors@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "redis-errors@npm:1.2.0"
+  checksum: f28ac2692113f6f9c222670735aa58aeae413464fd58ccf3fce3f700cae7262606300840c802c64f2b53f19f65993da24dc918afc277e9e33ac1ff09edb394f4
+  languageName: node
+  linkType: hard
+
+"redis-parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redis-parser@npm:3.0.0"
+  dependencies:
+    redis-errors: ^1.0.0
+  checksum: 89290ae530332f2ae37577647fa18208d10308a1a6ba750b9d9a093e7398f5e5253f19855b64c98757f7129cccce958e4af2573fdc33bad41405f87f1943459a
+  languageName: node
+  linkType: hard
+
 "reflect-metadata@npm:^0.1.13":
   version: 0.1.13
   resolution: "reflect-metadata@npm:0.1.13"
@@ -13698,6 +13857,13 @@ __metadata:
   dependencies:
     escape-string-regexp: ^2.0.0
   checksum: 052bf4d25bbf5f78e06c1d5e67de2e088b06871fa04107ca8d3f0e9d9263326e2942c8bedee3545795fc77d787d443a538345eef74db2f8e35db3558c6f91ff7
+  languageName: node
+  linkType: hard
+
+"standard-as-callback@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "standard-as-callback@npm:2.1.0"
+  checksum: 88bec83ee220687c72d94fd86a98d5272c91d37ec64b66d830dbc0d79b62bfa6e47f53b71646011835fc9ce7fae62739545d13124262b53be4fbb3e2ebad551c
   languageName: node
   linkType: hard
 
@@ -14489,6 +14655,13 @@ __metadata:
   version: 2.19.0
   resolution: "type-fest@npm:2.19.0"
   checksum: a4ef07ece297c9fba78fc1bd6d85dff4472fe043ede98bd4710d2615d15776902b595abf62bd78339ed6278f021235fb28a96361f8be86ed754f778973a0d278
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^3.6.1":
+  version: 3.8.0
+  resolution: "type-fest@npm:3.8.0"
+  checksum: f9a9ef00378dddd6af2be5cbb67ce4c3a61f6696c5f3ae88815c98266865766118343d928faec8a0efc012efe1d080f59bf62d8fdc382bf285f45d02dbc8fb66
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Yet another cache library for NestJS

This is for data that will be shared across multiple processes.
Thus, the keys are strings and the values are serializable.

The goals of this library are:
- Provide a nice interface for usage in Nestjs classes
- Integrate easily with the existing Nestjs ecosystem
- Leverage existing npm ecosystem for storage implementations

# Setup

Import the module in your app.
```ts
CacheModule.registerAsync({
  inject: [/* config */],
  useFactory: (/* config */): CacheModuleOptions => ({
    store: // create store implementation from config
  }),
})
```

# Usage

## Decorators

```ts
@Injectable()
class Service {
  @Cache({
    key: 'foo-bar',
    ttl: { minutes: 5 },
  })
  async fooBar() {
    // ...
  }
}
```

However, you will probably need to cache based on the args given, so:
```ts
@Injectable()
class Service {
  @Cache((id: string, year: number) => ({
    key: `foo-bar:${id}-${year}`,
    ttl: { minutes: 5 },
  }))
  async fooBar(id: string, year: number) {
    // ...
  }
}
```

## Service

The task you always most always want to do is skip expensive calculation if possible.
So the most useful method is `getOrCalculate`, which saves you the boilerplate for this logic.

```ts
declare const cache: CacheService; // injected somewhere
const result = await cache.getOrCalculate({
  key: `fooBar:${id}`,
  calculate: async () => {
    // do expensive calculation
  },
  ttl: { hour: 1 },
});
```

Naive functionality exists as well:
```ts
await cache.get('foo');
await cache.set('foo', 'bar');
await cache.delete('foo');
```

## Namespaces

A common use case is to namespace your cache keys, to help segment your cache store.
There's a `namespace` method which returns a modified cache service with the given prefix.
```ts
const usersCache = cache.namespace('users:');
```
Note that chaining these will stack the prefixes, not override them.
```ts
cache.namespace('foo:').namespace('bar:').get('baz'); // foo:bar:baz
```

## CacheItem

A wrapper is provided around a single cache keys as well.
This could help prevent having to store another variable for a computed key, or allow it to be passed around.
```ts
const cached = cache.item('1234');
const value = cached.getOrCalculate(async () => {
  // do expensive calculation
});
handleInvalidation(cached);
function handleInvalidation(cached: CacheItem) {
  if (isStale) {
    cached.delete();
  }
}
```

# Stores

Stores are the actual storage implementations the `CacheService` is backed by.

We provide stores for `ioredis`, `keyv`, `lru-cache`.
This should cover most use cases, but you can also implement your own.

## LRU / In Memory
```ts
import { LruStore } from '@seedcompany/cache/store/lru';
CacheModule.register({
  store: new LruStore({
    // options
  })
})
```

## Redis
```ts
import { RedisStore } from '@seedcompany/cache/store/redis';
import Redis from 'ioredis';
CacheModule.register({
  store: new RedisStore(
    new Redis('redis://localhost:6379')
  )
})
```

## Keyv
```ts
import { KeyvStore } from '@seedcompany/cache/store/keyv';
import Keyv from 'keyv';
CacheModule.register({
  store: new KeyvStore(
    new Keyv()
  )
})
```

## Chaining Multiple Stores

Multiple stores can be chained together with the `ChainStore`.
This could provide faster in memory cache falling back to a shared network cache.

```ts
import { ChainStore } from '@seedcompany/cache/store/chain';
CacheModule.register({
  store: new ChainStore([
    new LruStore({ max: 100 }),
    new RedisStore(),
  ])
})
```

# Adapters

We provide a few adapters to help integrate with other libraries.

## NestJS (HTTP?) Cache

Here's how to set up the NestJS cache module to be based on this one.

```ts
import { CacheModule as NestHttpCacheModule } from '@nestjs/common';
import { CacheModule, CacheService } from '@seedcompany/cache';
NestHttpCacheModule.registerAsync({
  imports: [CacheModule],
  inject: [CacheService],
  useFactory: (cache: CacheService): CacheModuleOptions => ({
    store: cache.namespace('http:').adaptTo.cacheManager(),
  }),
});
```
Continue on with the NestJS docs:
https://docs.nestjs.com/techniques/caching#interacting-with-the-cache-store

## Apollo Cache

Here's how to set up the Apollo cache to be based on this one.

```ts
GraphQLModule.forRootAsync<ApolloDriverConfig>({
  driver: ApolloDriver,
  imports: [CacheModule],
  inject: [CacheService],
  useFactory: (cache: CacheService) => ({
    cache: cache.namespace('apollo:').adaptTo.apollo(),
  }),
});
```

## Keyv Cache

Keyv cache is a very popular cache library.
Here's how to adapt our cache to its interface.

```ts
declare const cache: CacheService;
const kv = new Keyv({
  store: cache.adaptTo.keyv(),
});
```