### PR TITLE
feat(data-loader): allow `loadMany` to control result entries

### DIFF
--- a/packages/data-loader/src/data-loader.strategy.ts
+++ b/packages/data-loader/src/data-loader.strategy.ts
@@ -4,7 +4,12 @@ import { DataLoaderOptions } from './data-loader-options.type';
 export interface DataLoaderStrategy<Item, Key, CachedKey = Key> {
   loadMany(
     keys: readonly Key[],
-  ): Promise<ReadonlyArray<Item | { key: Key; error: Error }>>;
+  ): Promise<
+    | ReadonlyArray<
+        Item | { key: Key; error: Error } | readonly [Key, Item | Error]
+      >
+    | ReadonlyMap<Key, Item | Error>
+  >;
 
   getOptions?: () => DataLoaderOptions<Item, Key, CachedKey>;
 }

--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -306,7 +306,7 @@ const resolveDeclarationReplacement = (
           // @ts-expect-error This arg property should be typed as nullable ^
           localName: undefined,
         })
-      : restriction.replacement!;
+      : restriction.replacement;
   const replacement = {
     path: maybe(path, (path) =>
       interpolate(path, {
@@ -336,7 +336,7 @@ const resolveSpecifierReplacement = (
       importName: result.importName ?? specifier.name,
     };
   } else {
-    const { importName, importNames, ...rest } = restriction.replacement!;
+    const { importName, importNames, ...rest } = restriction.replacement;
     replacement = {
       ...rest,
       importName: importName ?? importNames?.[specifier.name] ?? specifier.name,


### PR DESCRIPTION
Now `loadMany` can control the result entries, by returning a list of entries or a `Map`. 
This allows expanding to multiple keys for a single item.

Some examples:
```ts
async loadMany(keys: Key[]) {
  const results = await [...];
  return results.flatMap((item) => [
    [item.key1, item],
    [item.key2, item],
  ]);
}
```

```ts
async loadMany(keys: Key[]) {
  const results = await [...];
  const resultMap = new Map();
  for (const item of results) {
    if (item.enabled) {
      resultMap.set(item.key, item);
    }
  }
  return resultMap;
}
```