### PR TITLE
feat(common): sortBy / cmpBy

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -10,4 +10,5 @@ export * from './many';
 export * from './non-enumerable';
 export * from './set-has';
 export * from './set-of';
+export * from './sort-by';
 export * from './types';

--- a/packages/common/src/sort-by.test.ts
+++ b/packages/common/src/sort-by.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { DateTime } from 'luxon';
+import { cmpBy, sortBy } from './sort-by';
+
+describe('sortBy', () => {
+  describe('simple primitives', () => {
+    type PT<T> = [string, readonly T[], readonly T[]];
+    test.each<PT<any>>([
+      ['strings', ['b', 'd', 'a', 'c'], ['a', 'b', 'c', 'd']],
+      ['numbers', [2, 4, 1, 3], [1, 2, 3, 4]],
+      ['bigints', [2n, 4n, 1n, 3n], [1n, 2n, 3n, 4n]],
+      [
+        'nullable',
+        [2, 4, null, 1, undefined, 3],
+        [1, 2, 3, 4, null, undefined],
+      ],
+      [
+        'Date / Symbol.toPrimitive',
+        [
+          new Date('2020-01-01'),
+          new Date('2020-01-03'),
+          new Date('2020-01-02'),
+        ],
+        [
+          new Date('2020-01-01'),
+          new Date('2020-01-02'),
+          new Date('2020-01-03'),
+        ],
+      ],
+      [
+        'DateTime / .valueOf()',
+        [
+          DateTime.fromISO('2020-01-01'),
+          DateTime.fromISO('2020-01-03'),
+          DateTime.fromISO('2020-01-02'),
+        ],
+        [
+          DateTime.fromISO('2020-01-01'),
+          DateTime.fromISO('2020-01-02'),
+          DateTime.fromISO('2020-01-03'),
+        ],
+      ],
+    ])('%s', (_, input, sorted) => {
+      expect(sortBy(input)).toEqual(sorted);
+    });
+  });
+
+  test('single criterion desc', () => {
+    expect(sortBy(['b', 'd', 'a', 'c'], [(x) => x, 'desc'])).toEqual([
+      'd',
+      'c',
+      'b',
+      'a',
+    ]);
+  });
+
+  test('empty criteria remains unsorted', () => {
+    const items = ['b', 'd', 'a', 'c'];
+    expect(sortBy(items, [])).toEqual(items);
+  });
+
+  test('sortees are called well', () => {
+    interface Palette {
+      hex: string;
+    }
+    const sortee = jest.fn((palette: Palette) => palette.hex);
+    expect(
+      sortBy([{ hex: 'blue' }, { hex: 'red' }, { hex: 'green' }], sortee),
+    ).toEqual([{ hex: 'blue' }, { hex: 'green' }, { hex: 'red' }]);
+    expect(sortee).toHaveBeenCalled();
+  });
+
+  test('types are ergonomic', () => {
+    expect(
+      sortBy(
+        [
+          { rgb: 'rgb(0, 0, 0)' },
+          null,
+          { hex: 'yellow' },
+          { rgb: null },
+          { rgb: 'rgb(255, 255, 255)' },
+          { hex: 'green' },
+        ],
+        // hex first, then rgb
+        [(palette) => palette?.hex, (p) => p?.rgb],
+      ),
+    ).toEqual([
+      { hex: 'green' },
+      { hex: 'yellow' },
+      { rgb: 'rgb(0, 0, 0)' },
+      { rgb: 'rgb(255, 255, 255)' },
+      null,
+      { rgb: null },
+    ]);
+  });
+
+  test('custom object', () => {
+    class YearQuarter {
+      constructor(public year: number, public quarter: number) {}
+      [Symbol.toPrimitive](hint: string) {
+        if (hint === 'number') {
+          return this.year * 10 + this.quarter;
+        }
+        return `Q${this.quarter} ${this.year}`;
+      }
+    }
+    expect(
+      sortBy(
+        [
+          { report: { quarter: new YearQuarter(2020, 1) } },
+          { report: { quarter: new YearQuarter(2019, 4) } },
+          { report: { quarter: new YearQuarter(2020, 2) } },
+          { report: { quarter: new YearQuarter(2019, 3) } },
+          { report: { quarter: new YearQuarter(2019, 1) } },
+        ],
+        (thing) => thing.report.quarter,
+      ),
+    ).toEqual([
+      { report: { quarter: new YearQuarter(2019, 1) } },
+      { report: { quarter: new YearQuarter(2019, 3) } },
+      { report: { quarter: new YearQuarter(2019, 4) } },
+      { report: { quarter: new YearQuarter(2020, 1) } },
+      { report: { quarter: new YearQuarter(2020, 2) } },
+    ]);
+
+    // test class defaults to string primitive, indicating that we do prefer `number` hint when calling.
+    expect(
+      [
+        new YearQuarter(2020, 1),
+        new YearQuarter(2019, 4),
+        new YearQuarter(2020, 2),
+        new YearQuarter(2019, 3),
+        new YearQuarter(2019, 1),
+      ].map((s) => String(s)),
+    ).toEqual(['Q1 2020', 'Q4 2019', 'Q2 2020', 'Q3 2019', 'Q1 2019']);
+  });
+
+  test('kitchen sink', () => {
+    // @ts-expect-error asserts sort criteria is only optional when the input list is a SortableValue[]
+    sortBy([{ name: 'Hermione Granger', age: 17 }]);
+
+    expect(
+      sortBy(
+        [
+          { name: 'Hermione Granger', age: 17 },
+          { name: 'Ron Weasley', age: 17 },
+          { name: 'Albus Dumbledore', age: 115 },
+          { name: 'Harry Potter', age: 17 },
+          { name: 'Severus Snape', age: 38 },
+        ],
+        // age first desc, then name asc
+        [[(character) => character.age, 'desc'], (character) => character.name],
+      ),
+    ).toEqual([
+      { name: 'Albus Dumbledore', age: 115 },
+      { name: 'Severus Snape', age: 38 },
+      { name: 'Harry Potter', age: 17 },
+      { name: 'Hermione Granger', age: 17 },
+      { name: 'Ron Weasley', age: 17 },
+    ]);
+  });
+});
+
+test('cmpBy interface is good and handles the bulk of logic', () => {
+  expect(
+    [
+      { name: 'Hermione Granger', age: 17 },
+      { name: 'Ron Weasley', age: 17 },
+      { name: 'Albus Dumbledore', age: 115 },
+      { name: 'Harry Potter', age: 17 },
+      { name: 'Severus Snape', age: 38 },
+    ].sort(
+      cmpBy(
+        // age first desc, then name asc
+        [[(character) => character.age, 'desc'], (character) => character.name],
+      ),
+    ),
+  ).toEqual([
+    { name: 'Albus Dumbledore', age: 115 },
+    { name: 'Severus Snape', age: 38 },
+    { name: 'Harry Potter', age: 17 },
+    { name: 'Hermione Granger', age: 17 },
+    { name: 'Ron Weasley', age: 17 },
+  ]);
+});

--- a/packages/common/src/sort-by.ts
+++ b/packages/common/src/sort-by.ts
@@ -1,0 +1,103 @@
+import { many, Many } from './many';
+import { Nil } from './types';
+
+export function sortBy<T extends SortableValue>(
+  list: Iterable<T>,
+  criteria?: SortCriteria<T>,
+): readonly T[];
+export function sortBy<T>(
+  list: Iterable<T>,
+  criteria: SortCriteria<T>,
+): readonly T[];
+export function sortBy<T>(
+  list: Iterable<T>,
+  criteria?: SortCriteria<T>,
+): readonly T[] {
+  return [...list].sort(cmpBy(criteria ?? ((x: T) => x as SortableValue)));
+}
+
+export const cmpBy = <T>(criteria: SortCriteria<T>) => {
+  const normalized = isSortee(criteria) ? [criteria] : many(criteria);
+  const builtCriteria = normalized.map((arg) =>
+    Array.isArray(arg) ? [arg[0], arg[1] === 'asc' ? 1 : -1] : [arg, 1],
+  );
+  return (a: T, b: T): number => {
+    for (const [fn, dir] of builtCriteria) {
+      const aVal = fn(a);
+      const bVal = fn(b);
+      const diff = compareSortables(aVal, bVal) * dir;
+      if (diff) {
+        return diff;
+      }
+    }
+    return 0;
+  };
+};
+
+const compareSortables = (a: SortableValue, b: SortableValue) => {
+  let diff = 0;
+  if (a == null || b == null) {
+    diff = a == null ? (b == null ? 0 : 1) : -1;
+  } else if (
+    (typeof a === 'number' && typeof b === 'number') ||
+    (typeof a === 'bigint' && typeof b === 'bigint')
+  ) {
+    diff = a < b ? -1 : a > b ? 1 : 0;
+  } else if (typeof a === 'string' && typeof b === 'string') {
+    diff = a.localeCompare(b);
+  } else if (typeof a === 'object' && typeof b === 'object') {
+    if (Symbol.toPrimitive in a && Symbol.toPrimitive in b) {
+      diff = compareSortables(
+        a[Symbol.toPrimitive]('number'),
+        b[Symbol.toPrimitive]('number'),
+      );
+    } else if ('valueOf' in a && 'valueOf' in b) {
+      diff = compareSortables(
+        a.valueOf() as SortableValue,
+        b.valueOf() as SortableValue,
+      );
+    }
+  }
+  return diff;
+};
+
+// Is this multiple criteria or a criterion tuple?
+const isSortee = <T>(criteria: SortCriteria<T>): criteria is SorteeWithDir<T> =>
+  Array.isArray(criteria) && (criteria[1] === 'asc' || criteria[1] === 'desc');
+
+export type SortCriteria<T> = Many<SortCriterion<T>>;
+export type SortCriterion<T> = Sortee<T> | SorteeWithDir<T>;
+type SorteeWithDir<T> = readonly [Sortee<T>, 'asc' | 'desc'];
+type Sortee<T> = (item: T) => SortableValue;
+
+/**
+ * A sortable value.
+ *
+ * I'm ignoring `.toString()` coercion here because it is rarely what is intended.
+ * If custom string coercion is desired, the custom object can implement `Symbol.toPrimitive`.
+ * We'll call it with `number` as the hint.
+ */
+type SortableValue =
+  | string
+  | number
+  | bigint
+  | HasToPrimitive
+  | HasNumericValueOf
+  | Nil;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive
+ */
+interface HasToPrimitive {
+  [Symbol.toPrimitive]: (
+    hint: 'number' | 'string' | 'default',
+  ) => string | number;
+}
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#numeric_coercion
+ */
+interface HasNumericValueOf {
+  valueOf: () => number | bigint;
+}


### PR DESCRIPTION
This adds `sortBy` and a lower level `cmpBy` functions.
This main point here is to reduce dependence on `lodash`.
Lodash has these as `sortBy` and `orderBy` (only in the latter can you specify `asc`/`desc`).

I have a feeling most of what lodash does in their implementations is over kill for modern JS.

I took the opportunity to tweak the signature.
- It accepts any `Iterable`, not just arrays.
- The order direction is optionally defined as a tuple with the sortee function. This correlation is easier to read IMO than the two separate arrays that correlate to each other.
- I thought about allowing the multiple sortees to be a variadic arg, but opted to keep it as a `Many` on the second arg. This allows room for a final options arg in future if needed. For example an `Intl.Collator` could be passed for large arrays of strings.

# Examples
```tsx
sortBy(['b', 'd', 'a', 'c']);

sortBy([
  { hex: 'blue' },
  { hex: 'red' },
  { hex: 'green' }
],
  (palette) => palette.hex
);

sortBy(
  [
    { name: 'Hermione Granger', age: 17 },
    { name: 'Ron Weasley', age: 17 },
    { name: 'Albus Dumbledore', age: 115 },
    { name: 'Harry Potter', age: 17 },
    { name: 'Severus Snape', age: 38 },
  ],
  // sort age first desc, then name asc
  [
    [(character) => character.age, 'desc'],
    (character) => character.name,
  ],
)
```
