### PR TITLE
feat(common): groupBy / groupToMapBy

### DIFF
--- a/packages/common/src/group-by.test.ts
+++ b/packages/common/src/group-by.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from '@jest/globals';
+import { groupBy, groupToMapBy } from './group-by';
+
+const characters = {
+  albus: { name: 'Albus Dumbledore', age: 115 },
+  severus: { name: 'Severus Snape', age: 38 },
+  harry: { name: 'Harry Potter', age: 17 },
+  hermione: { name: 'Hermione Granger', age: 17 },
+  ron: { name: 'Ron Weasley', age: 17 },
+};
+const entriesGroupedByAge = expect.arrayContaining([
+  [
+    17,
+    expect.arrayContaining([
+      characters.harry,
+      characters.hermione,
+      characters.ron,
+    ]),
+  ],
+  [38, [characters.severus]],
+  [115, [characters.albus]],
+]);
+
+describe('groupToMapBy', () => {
+  test('with Array', () => {
+    const grouped = groupToMapBy(
+      Object.values(characters),
+      (character) => character.age,
+    );
+    expect(grouped).toBeInstanceOf(Map);
+    expect([...grouped]).toEqual(entriesGroupedByAge);
+
+    // @ts-expect-error the map should be declared as readonly
+    grouped.set(undefined, undefined);
+  });
+
+  test('with Iterable', () => {
+    const grouped = groupToMapBy(
+      new Map(Object.entries(characters)).values(),
+      (character) => character.age,
+    );
+    expect([...grouped]).toEqual(entriesGroupedByAge);
+  });
+});
+
+test('groupBy', () => {
+  const grouped = groupBy(
+    Object.values(characters),
+    (character) => character.age,
+  );
+  expect(grouped).toBeInstanceOf(Array);
+  expect(grouped).toEqual(
+    expect.arrayContaining([
+      expect.arrayContaining([
+        characters.harry,
+        characters.hermione,
+        characters.ron,
+      ]),
+      [characters.severus],
+      [characters.albus],
+    ]),
+  );
+
+  // @ts-expect-error the array should be declared as readonly
+  grouped.push(undefined);
+  // @ts-expect-error the array should be declared as readonly
+  grouped[0].push(undefined);
+});

--- a/packages/common/src/group-by.ts
+++ b/packages/common/src/group-by.ts
@@ -1,0 +1,24 @@
+/**
+ * Groups the list/iterable of items based on the `by` function given.
+ * Returns an array of item groups.
+ */
+export const groupBy = <V>(
+  items: Iterable<V>,
+  by: (item: V) => unknown,
+): ReadonlyArray<readonly V[]> => [...groupToMapBy(items, by).values()];
+
+/**
+ * Groups the list/iterable of items based on the `by` function given.
+ * Returns a Map keyed by the keys determined from the `by` function,
+ * with the values being arrays of items that match that key.
+ */
+export const groupToMapBy = <K, V>(
+  items: Iterable<V>,
+  by: (item: V) => K,
+): ReadonlyMap<K, readonly V[]> =>
+  [...items].reduce((map, item) => {
+    const groupKey = by(item);
+    const prev = map.get(groupKey) ?? [];
+    map.set(groupKey, [...prev, item]);
+    return map;
+  }, new Map<K, V[]>());

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -4,6 +4,7 @@ export * from './async-pool';
 export * from './buffer';
 export * from './clean-join';
 export * from './delay';
+export * from './group-by';
 export * from './iterator';
 export * from './json-col';
 export * from './many';


### PR DESCRIPTION
This adds `groupBy` and `groupToMapBy` functions.
This main point here is to reduce dependence on `lodash`.

I took the opportunity to tweak the signatures.

lodash's `groupBy`: 
- only accepts an `Array`, where we accept an `Iterable`.
  This works well with new JS collections.
  ```tsx
  groupBy(new Map().values())
  groupBy(new Set())
  ```
- returns an `Object/Record` where we return a `ReadonlyMap`
  Obv I think immutable is better.
  I chose a `Map` over a `Record` since it's new school JS and it really made since here, because the entries could really be nullable (matching `Map.get(): T | undefined`) since they are based on the actual items in the list.
- I named it `groupToMapBy` instead...

This is because I have an additional function, called `groupBy`, that does the above and then grabs the values of the map.
The majority of the time this is what we are doing, so it made sense for that signature to take priority.

# Examples
```tsx
groupToMapBy([
  { name: 'Albus Dumbledore', age: 115 },
  { name: 'Severus Snape', age: 38 },
  { name: 'Harry Potter', age: 17 },
  { name: 'Hermione Granger', age: 17 },
  { name: 'Ron Weasley', age: 17 },
], character => character.age);
// => Map {
//   17 => [harry, hermione, ron],
//   38 => [severus],
//   115 => [albus],
// }
```
```tsx
groupBy([
  { name: 'Albus Dumbledore', age: 115 },
  { name: 'Severus Snape', age: 38 },
  { name: 'Harry Potter', age: 17 },
  { name: 'Hermione Granger', age: 17 },
  { name: 'Ron Weasley', age: 17 },
], character => character.age);
// => [
//   [harry, hermione, ron],
//   [severus],
//   [albus],
// ]
```
