### PR TITLE
feat(common): entries (of Records/Maps)

### DIFF
--- a/packages/common/src/entries.test.ts
+++ b/packages/common/src/entries.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@jest/globals';
+import { entries } from './entries';
+
+test('entries works', () => {
+  const colors = {
+    red: '#ff0000',
+    green: '#00ff00',
+    blue: '#0000ff',
+  } as const;
+  const expected = Object.entries(colors);
+
+  const fromRecord = entries(colors);
+  expect(fromRecord).toEqual(expected);
+  // @ts-expect-error the array should be declared as readonly
+  fromRecord.push(undefined);
+  // @ts-expect-error the tuple should be declared as readonly
+  fromRecord[0].push(undefined);
+  // @ts-expect-error the keys should be strict
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  fromRecord[0][0] === 'yellow';
+
+  // Map input works
+  const colorMap = new Map(Object.entries(colors));
+  expect(entries(colorMap)).toEqual(expected);
+
+  // Array input is a no-op
+  expect(entries(fromRecord)).toEqual(expected);
+});
+
+test('should infer strict keys from partial record', () => {
+  const colors: Partial<Record<'red' | 'blue' | 'green', string>> = {
+    red: '#ff0000',
+    green: '#00ff00',
+    blue: '#0000ff',
+  };
+
+  const fromRecord = entries(colors);
+  expect(fromRecord).toEqual(Object.entries(colors));
+  // @ts-expect-error inference should succeed making these keys strict
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  fromRecord[0][0] === 'yellow';
+});
+
+test('array index entries', () => {
+  const colors = ['red', 'green', 'blue'];
+
+  const fromRecord = entries(colors.entries());
+  expect(fromRecord).toEqual([
+    [0, 'red'],
+    [1, 'green'],
+    [2, 'blue'],
+  ]);
+  // @ts-expect-error keys should be numbers
+  fromRecord[0][0] as string;
+  // @ts-expect-error values should be strings
+  fromRecord[0][1] as number;
+});

--- a/packages/common/src/entries.ts
+++ b/packages/common/src/entries.ts
@@ -1,0 +1,28 @@
+/**
+ * Returns an array of key-value tuples for the given mapping.
+ *
+ * This is mainly for Records, where we cannot use `Object.entries` with strict keys.
+ * But this also accepts an `Iterable`, so it works with Maps, or an array of entries.
+ *
+ * I've made the hard choice of not calling `Array.entries()` when given arrays,
+ * but instead just returning the same shape.
+ * This could be unexpected, since the name is the same.
+ * I fear it will cause more confusion, since we can't know if the array
+ * should be converted to tuples with indexes, or if it's already a list of entry tuples.
+ * I wouldn't want to distinguish based on `Array` vs `Iterable` type to determine this as
+ * that also could be unexpected.
+ * Since using array indexes is less common, I'm favoring treating Array input the same as Iterable.
+ * This still works too, when actually wanting array indexes.
+ * ```ts
+ * entries([...].entries())
+ * ````
+ */
+export function entries<K, V>(
+  map: Iterable<readonly [key: K, value: V]>,
+): ReadonlyArray<readonly [key: K, value: V]>;
+export function entries<K extends string, V>(
+  object: Partial<Record<K, V>>,
+): ReadonlyArray<readonly [key: K, value: V]>;
+export function entries<K, V>(o: any): ReadonlyArray<readonly [K, V]> {
+  return Symbol.iterator in o ? [...o] : Object.entries(o);
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -4,6 +4,7 @@ export * from './async-pool';
 export * from './buffer';
 export * from './clean-join';
 export * from './delay';
+export * from './entries';
 export * from './group-by';
 export * from './iterator';
 export * from './json-col';


### PR DESCRIPTION
A staple in our API repos. I've upgrade it here to support Map input as well, so transitioning to using them is easier.

This exists because we use record types with strict keys in a lot of places, and:
- `Object.entries` doesn't have strict keys, only strings. Due to "objects can have more un-typed props something something blah blah". It's totally fine for our use cases since we always use this on plain data objects, not classes or whatever with more things happening on them.
- `Map.get(): V | undefined` This forced nullable is unfortunate, because in a lot of cases we do have values for every key in the mapping. For the cases where this isn't true we should switch to using Maps.

```ts
const colors = {
  red: '#ff0000',
  green: '#00ff00',
  blue: '#0000ff',
};
entries(colors) // => ReadonlyArray<readonly [(key: "red" | "green" | "blue"), value: string]>

const colorMap = new Map(entries);
entries(colorMap) // => ReadonlyArray<readonly [(key: "red" | "green" | "blue"), value: string]>
```