### PR TITLE
feat(common): mapOf

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -9,6 +9,7 @@ export * from './group-by';
 export * from './iterator';
 export * from './json-col';
 export * from './many';
+export * from './map-of';
 export * from './non-enumerable';
 export * from './set-has';
 export * from './set-of';

--- a/packages/common/src/map-of.test.ts
+++ b/packages/common/src/map-of.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@jest/globals';
+import { entries } from './entries';
+import { mapOf } from './map-of';
+
+test('mapOf works', () => {
+  const map = mapOf({
+    red: '#ff0000',
+    green: '#00ff00',
+    blue: '#0000ff',
+  });
+  expect(map).toBeInstanceOf(Map);
+  // @ts-expect-error the map should be declared as readonly
+  map.set(undefined, undefined);
+  // @ts-expect-error the keys should be strict
+  map.get('yellow');
+
+  // Map input works
+  expect(mapOf(map)).toEqual(map);
+
+  // Entries input works
+  expect(mapOf(entries(map))).toEqual(map);
+});

--- a/packages/common/src/map-of.ts
+++ b/packages/common/src/map-of.ts
@@ -1,0 +1,17 @@
+import { entries } from './entries';
+
+/**
+ * An easier way to create an immutable map.
+ *
+ * Also, since this is a function, it can be passed without
+ * having to create a function to call the constructor.
+ */
+export function mapOf<const K, const V>(
+  entries: Iterable<readonly [key: K, value: V]>,
+): ReadonlyMap<K, V>;
+export function mapOf<const K extends string, const V>(
+  entries: Partial<Record<K, V>>,
+): ReadonlyMap<K, V>;
+export function mapOf<K, V>(items?: any): ReadonlyMap<K, V> {
+  return new Map(items ? entries(items) : undefined);
+}


### PR DESCRIPTION
Kinda the inverse of `entries`.
Allows creating a map from another map, a record, a list of entries, etc.
Main benefits are it returns the map as readonly because immutability, and it can passed as a function to another caller since it's not a constructor.

```ts
mapOf({
  red: '#ff0000',
  green: '#00ff00',
  blue: '#0000ff',
});

const map = mapOf([
  ['red', '#ff0000'],
  ['green', '#00ff00'],
  ['blue', '#0000ff'],
]);

const copied = mapOf(map);

someFunction(..., mapOf);
```