### PR TITLE
feat(common): mapEntries, mapKeys, mapValues

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -10,6 +10,7 @@ export * from './iterator';
 export * from './json-col';
 export * from './many';
 export * from './map-of';
+export * from './map-to';
 export * from './non-enumerable';
 export * from './set-has';
 export * from './set-of';

--- a/packages/common/src/map-to.test.ts
+++ b/packages/common/src/map-to.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from '@jest/globals';
+import { mapOf } from './map-of';
+import { EntriesResult, mapEntries, mapKeys, mapValues } from './map-to';
+
+const colorList = ['red', 'blue', 'green'] as const;
+const colorRecord = {
+  red: '#f00',
+  green: '#0f0',
+  blue: '#00f',
+} as const;
+const colorMap = mapOf(colorRecord);
+
+const upperCase = <const T extends string>(str: T) =>
+  str.toUpperCase() as Uppercase<T>;
+
+describe('mapEntries', () => {
+  test('fromRecord', () => {
+    const result = mapEntries(colorRecord, ([color, hex], { SKIP }) =>
+      color !== 'red' ? [`${color}!`, upperCase(hex)] : SKIP,
+    ).asRecord;
+    expect(result).toEqual({
+      'green!': '#0F0',
+      'blue!': '#00F',
+    });
+  });
+  test('fromMap', () => {
+    const result = mapEntries(colorMap, ([color, hex], { SKIP }) =>
+      color !== 'red' ? [`${color}!`, upperCase(hex)] : SKIP,
+    ).asRecord;
+    expect(result).toEqual({
+      'green!': '#0F0',
+      'blue!': '#00F',
+    });
+  });
+  test('fromList', () => {
+    const result = mapEntries(colorList, (color, { SKIP }) =>
+      color !== 'red' ? [`${color}!`, upperCase(color)] : SKIP,
+    ).asRecord;
+    expect(result).toEqual({
+      'green!': 'GREEN',
+      'blue!': 'BLUE',
+    });
+  });
+  test('fromList helper', () => {
+    const result = mapEntries.fromList(colorList, (color, { SKIP }) =>
+      color !== 'red' ? [`${color}!`, upperCase(color)] : SKIP,
+    ).asRecord;
+    expect(result).toEqual({
+      'green!': 'GREEN',
+      'blue!': 'BLUE',
+    });
+  });
+});
+
+describe('mapKeys', () => {
+  test('fromRecord', () => {
+    const result = mapKeys(colorRecord, (color, hex, { SKIP }) =>
+      color !== 'red' ? upperCase(hex) : SKIP,
+    ).asRecord;
+    expect(result).toEqual({
+      '#0F0': '#0f0',
+      '#00F': '#00f',
+    });
+  });
+  test('fromMap', () => {
+    const result = mapKeys(colorMap, (color, hex, { SKIP }) =>
+      color !== 'red' ? upperCase(hex) : SKIP,
+    ).asRecord;
+    expect(result).toEqual({
+      '#0F0': '#0f0',
+      '#00F': '#00f',
+    });
+  });
+  test('fromList', () => {
+    const result = mapKeys.fromList(colorList, (color, { SKIP }) =>
+      color !== 'red' ? upperCase(color) : SKIP,
+    ).asRecord;
+    expect(result).toEqual({
+      GREEN: 'green',
+      BLUE: 'blue',
+    });
+  });
+});
+
+describe('mapValues', () => {
+  test('fromRecord', () => {
+    const result = mapValues(colorRecord, (color, hex, { SKIP }) =>
+      color !== 'red' ? upperCase(hex) : SKIP,
+    ).asRecord;
+    expect(result).toEqual({
+      green: '#0F0',
+      blue: '#00F',
+    });
+  });
+  test('fromMap', () => {
+    const result = mapValues(colorMap, (color, hex, { SKIP }) =>
+      color !== 'red' ? upperCase(hex) : SKIP,
+    ).asRecord;
+    expect(result).toEqual({
+      green: '#0F0',
+      blue: '#00F',
+    });
+  });
+  test('fromList', () => {
+    const result = mapValues.fromList(colorList, (color, { SKIP }) =>
+      color !== 'red' ? upperCase(color) : SKIP,
+    ).asRecord;
+    expect(result).toEqual({
+      green: 'GREEN',
+      blue: 'BLUE',
+    });
+  });
+});
+
+test('EntriesResult', () => {
+  const result = new EntriesResult([
+    ['green!', '#0F0'],
+    ['blue!', '#00F'],
+  ]);
+
+  expect(result.asRecord).toEqual({
+    'green!': '#0F0',
+    'blue!': '#00F',
+  });
+
+  const map = result.asMap;
+  expect(map).toBeInstanceOf(Map);
+  expect(map.size).toBe(2);
+  expect(map.get('green!')).toBe('#0F0');
+  expect(map.get('blue!')).toBe('#00F');
+
+  expect(result.entries).toEqual(
+    expect.arrayContaining([
+      ['green!', '#0F0'],
+      ['blue!', '#00F'],
+    ]),
+  );
+
+  expect([...result]).toEqual(
+    expect.arrayContaining([
+      ['green!', '#0F0'],
+      ['blue!', '#00F'],
+    ]),
+  );
+});

--- a/packages/common/src/map-to.ts
+++ b/packages/common/src/map-to.ts
@@ -1,0 +1,253 @@
+import { entries } from './entries';
+import { mapOf } from './map-of';
+
+const SKIP = Symbol.for('SKIP');
+type SKIP = typeof SKIP;
+
+interface Options {
+  SKIP: SKIP;
+}
+
+type EntryMapper<Entry, NewKey, NewValue> = (
+  item: Entry,
+  options: Options,
+) => readonly [key: NewKey, value: NewValue] | SKIP;
+
+/**
+ * Converts a Record/Map/`Iterable` to a new Map/Record.
+ *
+ * It takes anything having entries, which could be:
+ *   - a plain object
+ *   - a Map
+ *   - an array of items
+ *   - an array of [key, value] tuples
+ *   - an `Iterable` of [key, value] tuples
+ *     (many objects produce this, even
+ *       the output of this function can be used as input)
+ *
+ * The function given is called with each key/value pair/tuple,
+ * and it should return a tuple of the new key/value pair.
+ *
+ * The output of this function is a result class.
+ * It can be used to convert the results to a Map or a Record,
+ * or even passed to another function that accepts an `Iterable` of entries.
+ * This allows each use-case to use the type best suited for it.
+ *
+ * It's a common practice to filter out some pairs as well,
+ * this can be done with the `SKIP` option, see example below.
+ *
+ * @example
+ * const res = mapEntries({ a: 1, b: 2 }, ([key, value]) =>
+ *   [key.toUpperCase(), value * 2]
+ * );
+ * // Choose the output type best suited for the specific use case.
+ * res.asRecord // => { A: 2, B: 4 }
+ * res.asMap // => Map of { A: 2, B: 4 }
+ *
+ * @example
+ * const userColors = new Map<User, string>([
+ *   [user1, 'red'],
+ *   [user2, 'blue'],
+ * ]);
+ * mapEntries(userColors, ([user, color]) =>
+ *   [user, color.toUpperCase()]
+ * ).asMap // => Map { user1: 'RED', user2: 'BLUE' }
+ *
+ * @example From a list
+ * mapEntries(['red', 'blue', 'green'], (color) =>
+ *   [color, color.toUpperCase()]
+ * ).asRecord // => { red: 'RED', blue: 'BLUE', green: 'GREEN' }
+ *
+ * @example Filtering out/skipping some entries
+ * mapEntries({ a: 10, b: 0, c: 4 }, ([key, value], { SKIP }) =>
+ *   value <= 0 ? SKIP : [key, value * 2]
+ * ).asRecord // => { a: 2, c: 4 }
+ */
+export function mapEntries<const Entry, const NewKey, const NewValue>(
+  entries: Iterable<Entry>,
+  mapper: EntryMapper<Entry, NewKey, NewValue>,
+): EntriesResult<NewKey, NewValue>;
+export function mapEntries<
+  const OldKey extends keyof any,
+  const OldValue,
+  const NewKey,
+  const NewValue,
+>(
+  record: Partial<Record<OldKey, OldValue>>,
+  mapper: EntryMapper<
+    readonly [key: OldKey, value: OldValue],
+    NewKey,
+    NewValue
+  >,
+): EntriesResult<NewKey, NewValue>;
+export function mapEntries(list: any, mapper: EntryMapper<any, any, any>) {
+  return new EntriesResult(
+    entries(list).flatMap((item) => {
+      const res = mapper(item, { SKIP });
+      return res === SKIP ? [] : [res];
+    }),
+  );
+}
+
+/**
+ * This is the same as {@link mapEntries}, but it's here for symmetry with the other map functions.
+ */
+mapEntries.fromList = mapEntries;
+
+type KeyMapper<OldKey, Value, NewKey> = (
+  key: OldKey,
+  value: Value,
+  options: Options,
+) => NewKey | SKIP;
+
+/**
+ * Converts a Record/Map/`Iterable`-of-entries to a new Map/Record.
+ *
+ * This is similar to {@link mapEntries}, but is a shortcut for when the values should remain the same.
+ *
+ * The entries-like input is the same as {@link mapEntries}, except lists/iterables of values are not allowed, they have to be entries.
+ * See {@link mapKeys.fromList} for conversion from a list.
+ *
+ * The mapper function is given the key as the first argument, and the value as the second.
+ * This saves the caller from having to destructure the entry tuple.
+ *
+ * @example
+ * mapKeys({ a: 1, b: 2 }, (key) => key.toUpperCase()).asRecord // => { A: 1, B: 2 }
+ *
+ * @example
+ * mapKeys({ a: 1, b: 0, c: 4 }, (key, value, { SKIP }) =>
+ *   value <= 0 ? SKIP : key.toUpperCase()
+ * ).asRecord // => { A: 1, C: 4 }
+ */
+export function mapKeys<const OldKey, const NewKey, const Value>(
+  entries: Iterable<readonly [key: OldKey, value: Value]>,
+  mapper: KeyMapper<OldKey, Value, NewKey>,
+): EntriesResult<NewKey, Value>;
+export function mapKeys<
+  const OldKey extends keyof any,
+  const NewKey,
+  const Value,
+>(
+  record: Partial<Record<OldKey, Value>>,
+  mapper: KeyMapper<OldKey, Value, NewKey>,
+): EntriesResult<NewKey, Value>;
+export function mapKeys(list: any, mapper: KeyMapper<any, any, any>) {
+  return new EntriesResult(
+    entries(list).flatMap(([oldKey, value]) => {
+      const newKey = mapper(oldKey, value, { SKIP });
+      return newKey === SKIP ? [] : [[newKey, value]];
+    }),
+  );
+}
+
+/**
+ * Converts a List/`Iterable`-of-items to a new Map/Record, where the input items become the values.
+ *
+ * @example
+ * mapKeys.fromList(['red', 'blue', 'green'], (color) =>
+ *   color.toUpperCase()
+ * ).asRecord // => { RED: 'red', BLUE: 'blue', GREEN: 'green' }
+ *
+ * @example
+ * mapKeys.fromList(new Set(['red', 'blue', 'green']), (color, { SKIP }) =>
+ *   color === 'green' ? SKIP : color.toUpperCase()
+ * ).asRecord // => { RED: 'red', BLUE: 'blue' }
+ */
+mapKeys.fromList = <const Item, const NewKey>(
+  entries: Iterable<Item>,
+  mapper: (value: Item, options: Options) => NewKey | SKIP,
+) => mapKeys([...entries].entries(), (_, item, opts) => mapper(item, opts));
+
+type ValueMapper<Key, OldValue, NewValue> = (
+  key: Key,
+  value: OldValue,
+  options: Options,
+) => NewValue | SKIP;
+
+/**
+ * Converts a Record/Map/`Iterable`-of-entries to a new Map/Record.
+ *
+ * This is similar to {@link mapEntries}, but is a shortcut for when the keys should remain the same.
+ *
+ * The entries-like input is the same as {@link mapEntries}, except lists/iterables of values are not allowed, they have to be entries.
+ * See {@link mapValues.fromList} for conversion from a list.
+ *
+ * The mapper function is given the key as the first argument, and the value as the second.
+ * This saves the caller from having to destructure the entry tuple.
+ *
+ * @example
+ * mapValues({ a: 1, b: 2 }, (_, value) => value * 2).asRecord // => { a: 2, b: 4 }
+ *
+ * @example
+ * mapValues({ a: 1, b: 0, c: 4 }, (key, value, { SKIP }) =>
+ *   value <= 0 ? SKIP : value * 2
+ * ).asRecord // => { a: 1, b: 4 }
+ */
+export function mapValues<const Key, const OldValue, const NewValue>(
+  entries: Iterable<readonly [key: Key, value: OldValue]>,
+  mapper: ValueMapper<Key, OldValue, NewValue>,
+): EntriesResult<Key, NewValue>;
+export function mapValues<
+  const Key extends keyof any,
+  const OldValue,
+  const NewValue,
+>(
+  record: Partial<Record<Key, OldValue>>,
+  mapper: ValueMapper<Key, OldValue, NewValue>,
+): EntriesResult<Key, NewValue>;
+export function mapValues(list: any, mapper: ValueMapper<any, any, any>) {
+  return new EntriesResult(
+    entries(list).flatMap(([key, oldValue]) => {
+      const newValue = mapper(key, oldValue, { SKIP });
+      return newValue === SKIP ? [] : [[key, newValue]];
+    }),
+  );
+}
+
+/**
+ * Converts a List/`Iterable`-of-items to a new Map/Record, where the input items become the keys.
+ *
+ * @example
+ * mapValues.fromList(['red', 'blue', 'green'], (color) =>
+ *   color.toUpperCase()
+ * ).asRecord // => { red: 'RED', blue: 'BLUE', green: 'GREEN' }
+ *
+ * @example
+ * mapValues.fromList(new Set(['red', 'blue', 'green']), (color, { SKIP }) =>
+ *   color === 'green' ? SKIP : color.toUpperCase()
+ * ).asRecord // => { red: 'RED', blue: 'BLUE' }
+ */
+mapValues.fromList = <const Item, const NewVal>(
+  entries: Iterable<Item>,
+  mapper: (value: Item, options: { SKIP: typeof SKIP }) => NewVal | typeof SKIP,
+) =>
+  mapValues(
+    [...entries].map((item) => [item, item] as const),
+    (_, item, opts) => mapper(item, opts),
+  );
+
+/**
+ * The output of {@link mapEntries}, {@link mapKeys}, {@link mapValues}.
+ *
+ * It allows easily converting the results to a Map or a Record
+ * or passing to another function that accepts an `Iterable` of entries.
+ */
+export class EntriesResult<const Key, const Value>
+  implements Iterable<readonly [key: Key, value: Value]>
+{
+  constructor(
+    readonly entries: ReadonlyArray<readonly [key: Key, value: Value]>,
+  ) {}
+
+  get asRecord(): Readonly<Record<Key extends keyof any ? Key : never, Value>> {
+    return Object.fromEntries(this.entries);
+  }
+
+  get asMap() {
+    return mapOf(this.entries);
+  }
+
+  *[Symbol.iterator]() {
+    yield* this.entries;
+  }
+}


### PR DESCRIPTION
This is a big one. It aims to replace the `mapFromList` function (and more) used in dozens of places.
This was really hard because I had mixed feelings about the former function and how to improve it.

<details>
<summary>

# `mapFromList` Cons (collapsed)

</summary>


`mapFromList` is a single function, so that one signature was easy to go and remember.
 But in a lot of ways it fell short. It only accepted a _list_, so any input that wasn't needed to be convert to that first.
 A lot of times only the _key_ or _value_ needed to be altered, but the other still had to passed through anyways. 

## New native functions could render this function not very valuable.
Here's an example of how small native APIs are (with caveats)
```ts
Object.fromEntries(list.flatMap(item => [[item.key, item.value]]))
new Map(           list.map(item => [item.key, item.value]))
```
## Entries -> Record/Map
`Object.fromEntries` and `new Map` both create records/maps from a list of entries, easily.
However, both of these don't have the best types.
`fromEntries` returns keys as `strings` always, not the strict keys that entries have. This is the biggest con.
Both types return mutable, which isn't ideal.

I just made `mapOf` (#24) and I considered (and still am) making a `recordOf` helpers to fix these type problems.

## flatMap tuple return
With the second example (`.map`), TS correctly infers that it's mapping a tuple, and keeps the key & value types independent and correct.
However, with `Array.flatMap`, we have to wrap the tuple in another array as `flatMap` treats returned arrays as individual items to flatten. TS also can't infer that this double array is a list of tuples without an `as const`.
So why use `flatMap`? Well many times we are trying to filter out some of the key/value pairs. So we have something like this
```ts
[...].flatMap((item) =>
  keepItem(item) ? ([[item.key, item.value]] as const) : []
)
```
That's a lot of syntax to grok/ignore. Compared to
```ts
mapFromList([...], (item) =>
  keepItem(item) ? [item.key, item.value] : null
)
```

## Only changing keys _or_ values a lot of times

Many times we are converting a list to a map where the list items are the keys and we are creating values from the keys, or visa-versa.
Like this
```ts
mapFromList(props, prop => [
  prop,
  privileges.can('edit', prop)
])
```
It would be nice to not have to specify the tuple with the key since that's not changing.

## Mapping existing maps to new keys/values

Sometimes we have a record/object, and want to change/map the keys/values to something else.
We could do
```ts
mapFromList(entries(existing), ([key, value]) => ...))
```
But haven't, because maybe the lodash `mapKeys` & `mapValues` functions were easier.

## Output Maps?

Finally, I think there are places where we could migrate to using a `Map` now instead of an object. So if I was going to rewrite this `mapFromList` function, should it return a `Map` instead? 

</details>
...This is a lot to consider, and not an easy solution.

# New Functions

## `mapEntries`

Starting with the one that most closely resembles, `mapFromList`.
```ts
mapEntries(['red', 'blue', 'green'], (color) =>
  [color, color.toUpperCase()]
).asRecord
```

This function, however, accepts many more types:
- a plain object/"Record"
- a `Map`
- an `Array` of items
- an `Iterable` of items (many objects are this)

#### Map vs Record/Plain Object
As hinted at in the example above, I decided to not choose between a `Map` output or a `Record` output, but instead allow both.
Upon recent study, there are situations where both are useful.
`Maps` are better when an entry could be nullable, since `Map.get()` has a nullable output. Or when keys need to be objects.
`Records` are better when plain objects are required for the situation: i.e. JSON output, or passing options to a library, etc.

So after the call you add `.asRecord` or `.asMap` to convert the entries to the shape that best fits the situation.
Prettier seems to like this as well, and doesn't drastically change the formatting with this tail.

## Skipping entries

In `mapFromList` entries are skipped if mapper function returns `null`.
Here, instead of the `null` return, we have a special `SKIP` symbol.
```ts
mapEntries({ a: 10, b: 0, c: 4 }, ([key, value], { SKIP }) =>
  value <= 0 ? SKIP : [key, value * 2]
)
```
I believe this makes the intent more clear to both the code reader and the function implementation.
This is more explicit than convention based on value or lack there of.

## More examples

```ts
const res = mapEntries({ a: 1, b: 2 }, ([key, value]) =>
  [key.toUpperCase(), value * 2]
);
// Choose the output type best suited for the specific use case.
res.asRecord // => { A: 2, B: 4 }
res.asMap // => Map of { A: 2, B: 4 }
```
```ts
const userColors = new Map<User, string>([
  [user1, 'red'],
  [user2, 'blue'],
]);
mapEntries(userColors, ([user, color]) =>
  [user, color.toUpperCase()]
).asMap // => Map { user1: 'RED', user2: 'BLUE' }
```
```ts
mapEntries(['red', 'blue', 'green'], (color) =>
  [color, color.toUpperCase()]
).asRecord // => { red: 'RED', blue: 'BLUE', green: 'GREEN' }
```

# `mapKeys` / `mapValues`

As alluded to above these are two shortcut functions when the key or value doesn't need to be touched.

```ts
mapValues({ a: 1, b: 2 }, (_, value) => value * 2).asRecord // => { a: 2, b: 4 }
```
These functions also accept Maps and `Iterables` of tuple entries (key/value pairs). They do not accept a list of values see below. We have to be explicit with the tuple entries as the one that's not being mapped by the caller is used internally.

The key & value are passed as two arguments to the mapper function too, so the caller doesn't have to have tuple destructuring syntax.

Here the `SKIP` symbol is more important as the mapper output value is the actual value, so we can't assume anything.
```ts
mapValues({ a: 1, b: 0, c: 4 }, (key, value, { SKIP }) =>
  value <= 0 ? SKIP : value * 2
).asRecord // => { a: 1, b: 4 }
```

# `mapKeys/Values.fromList`

This variation accepts a list/`Iterable` of _anything_, which will be used as the respective value or key.

```ts
mapValues.fromList(['red', 'blue', 'green'], (color) =>
  color.toUpperCase()
).asRecord // => { red: 'RED', blue: 'BLUE', green: 'GREEN' }
```

`Sets` are `Iterables` of values, so they work here too:
```ts
mapValues.fromList(setOf(['red', 'blue']), (color) => color.toUpperCase())
  .asRecord // => { red: 'RED', blue: 'BLUE' }
```

We also have `mapEntries.fromList` for symmetry with the others, but this one is functionally no different than `mapEntries`.

# Closing Thoughts

- Here, I've added 5 functions that aim to do exactly what is needed for each specific use case.
- This functionality allows seamless transitions between maps and records and other iterables.
- Looking at the source code, there's very little logic. Most of it is types & docs.
- I believe these are worth it, even with a native JS variation being only slightly larger.
- They are still here once, so it's not like these ~250 lines are copy/pasted into each repo.
- This further reduces dependance on lodash functions.

