### PR TITLE
fix(scripture): merging ranges with the same endpoint

### DIFF
--- a/packages/scripture/src/merge-to-minimal-set.test.ts
+++ b/packages/scripture/src/merge-to-minimal-set.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from '@jest/globals';
+import { labelOfVerseRanges } from './label-of-verse-ranges';
+import { parseScripture } from './parser';
+
+describe('mergeVerseRanges', () => {
+  it.each([
+    ['Genesis 1:1, 1–4', 'Genesis 1–4'],
+    ['Genesis 1:2, 1–4', 'Genesis 1–4'],
+    ['Genesis 1:1-3:2, 1–4', 'Genesis 1–4'],
+    ['Genesis 1-5, 1–4', 'Genesis 1–5'],
+    ['Genesis 2-3, 1–4', 'Genesis 1–4'],
+    ['Genesis 1-4, 2-3', 'Genesis 1–4'],
+    ['Genesis 1-4, 1–5', 'Genesis 1–5'],
+    ['Genesis 1-4, 2–5', 'Genesis 1–5'],
+    ['Genesis 1-3, 4–5', 'Genesis 1–5'],
+    ['Genesis 1:1, 1:1', 'Genesis 1:1'],
+    ['Genesis 1:1, 1:2', 'Genesis 1:1–2'],
+    ['Genesis 1:1, 1:3', 'Genesis 1:1, 1:3'],
+    ['Genesis 1:3, 1:1', 'Genesis 1:1, 1:3'],
+  ])('%s', (input, output) => {
+    expect(labelOfVerseRanges(parseScripture(input))).toEqual(output);
+  });
+});

--- a/packages/scripture/src/merge-to-minimal-set.ts
+++ b/packages/scripture/src/merge-to-minimal-set.ts
@@ -20,7 +20,7 @@ export const mergeVerseRanges = (
         }
         // if current overlaps item or current's end is adjacent to item's start
         if (
-          (current.end > item.start && current.start < item.end) ||
+          (current.end >= item.start && current.start <= item.end) ||
           +current.end === +item.start - 1
         ) {
           return [


### PR DESCRIPTION
Both of these ranges were previously considered minimal
```
Genesis 1:1, 1–4
Genesis 1:1, 1:1
```
Now they are correctly merged to
```
Genesis 1–4
Genesis 1:1
```