### PR TITLE
fix: sourcemap paths

### DIFF
--- a/packages/cache/tsup.config.ts
+++ b/packages/cache/tsup.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'tsup';
 
 export const tsup = defineConfig({
   entry: ['src', '!src/**/*.test.ts'],
+  esbuildOptions: (opts) => {
+    opts.sourceRoot = './dist/';
+  },
   format: ['cjs', 'esm'],
   dts: true,
   sourcemap: true,

--- a/packages/common/tsup.config.ts
+++ b/packages/common/tsup.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'tsup';
 
 export const tsup = defineConfig({
   entry: ['src/index.ts', 'src/temporal/luxon/index.ts', '!src/**/*.test.ts'],
+  esbuildOptions: (opts) => {
+    opts.sourceRoot = './dist/';
+  },
   external: ['@seedcompany/common'],
   format: ['cjs', 'esm'],
   dts: true,

--- a/packages/email/tsup.config.ts
+++ b/packages/email/tsup.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'tsup';
 
 export const tsup = defineConfig({
   entry: ['src', '!src/**/*.test.ts'],
+  esbuildOptions: (opts) => {
+    opts.sourceRoot = './email/dist/';
+  },
   bundle: false,
   format: ['cjs'],
   inject: ['./react-shim.ts'],

--- a/packages/nest/tsup.config.ts
+++ b/packages/nest/tsup.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'tsup';
 
 export const tsup = defineConfig({
   entry: ['src', '!src/**/*.test.ts'],
+  esbuildOptions: (opts) => {
+    opts.sourceRoot = './nest/dist/';
+  },
   format: ['cjs', 'esm'],
   dts: true,
   sourcemap: true,

--- a/packages/scripture/tsup.config.ts
+++ b/packages/scripture/tsup.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'tsup';
 
 export const tsup = defineConfig({
   entry: ['src/index.ts', '!src/**/*.test.ts'],
+  esbuildOptions: (opts) => {
+    opts.sourceRoot = './scripture/dist/';
+  },
   format: ['cjs', 'esm'],
   target: 'es2019',
   dts: true,


### PR DESCRIPTION
Since we build to dist/ but then change to publish dist/ as the package root, the path was messed up.
It has `../src` which normalizes to removing the package name. i.e. `node_modules/@seedcompany/src/...`.
Setting the `sourceRoot` changes path to `./dist/../src` to cancel this out.