### PR TITLE
Port enum changes from Cord

### DIFF
--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -10,7 +10,9 @@
     "@nestjs/common": "^10",
     "@nestjs/core": "^10",
     "@nestjs/graphql": "^12",
-    "@seedcompany/common": ">0.3 <1"
+    "@seedcompany/common": ">0.3 <1",
+    "change-case": "^5.4.4",
+    "title-case": "^4.3.1"
   },
   "peerDependencies": {
     "@nestjs/common": "^10",

--- a/packages/nest/src/make-enum.ts
+++ b/packages/nest/src/make-enum.ts
@@ -12,13 +12,18 @@ export type MadeEnum<
   Values extends string,
   ValueDeclaration = EnumValueDeclarationShape,
   Extra = unknown,
-> = {
-  readonly [Value in Values & string]: Value;
-} & EnumHelpers<
+> = EnumHelpers<
   Values,
   ValueDeclaration & ImplicitValueDeclarationShape<Values>
 > &
-  Readonly<Extra>;
+  Readonly<Extra> &
+  // Allow direct access to the values if they're strict.
+  // For generic `string` we don't allow this.
+  // This allows strict values to be compatible with generic values.
+  // MadeEnum<string> = MadeEnum<X>
+  (string extends Values
+    ? unknown // ignore addition
+    : { readonly [Value in Values & string]: Value });
 
 interface EnumOptions<
   ValueDeclaration extends EnumValueDeclarationShape,
@@ -218,7 +223,7 @@ type NormalizedValueDeclaration<Declaration extends EnumValueDeclarationShape> =
 interface EnumHelpers<Values extends string, ValueDeclaration> {
   readonly values: ReadonlySet<Values>;
   readonly entries: ReadonlyArray<Readonly<ValueDeclaration>>;
-  readonly entry: (value: Values) => Readonly<ValueDeclaration>;
+  readonly entry: <V extends Values>(value: V) => Readonly<ValueDeclaration>;
   readonly has: <In extends string>(
     value: In & {},
   ) => value is In & Values & {};

--- a/packages/nest/src/make-enum.ts
+++ b/packages/nest/src/make-enum.ts
@@ -10,12 +10,15 @@ export type EnumType<Enum> = Enum extends MadeEnum<infer Values, any, any>
 
 export type MadeEnum<
   Values extends string,
-  Extra = unknown,
   ValueDeclaration = EnumValueDeclarationShape,
+  Extra = unknown,
 > = {
   readonly [Value in Values & string]: Value;
-} & Readonly<Extra> &
-  EnumHelpers<Values, ValueDeclaration & ImplicitValueDeclarationShape<Values>>;
+} & EnumHelpers<
+  Values,
+  ValueDeclaration & ImplicitValueDeclarationShape<Values>
+> &
+  Readonly<Extra>;
 
 interface EnumOptions<
   ValueDeclaration extends EnumValueDeclarationShape,
@@ -71,8 +74,8 @@ export const makeEnum = <
   input: EnumOptions<ValueDeclaration, Extra>,
 ): MadeEnum<
   ValuesOfDeclarations<ValueDeclaration>,
-  [Extra] extends [never] ? unknown : Extra,
-  NormalizedValueDeclaration<ValueDeclaration>
+  NormalizedValueDeclaration<ValueDeclaration>,
+  [Extra] extends [never] ? unknown : Extra
 > => {
   const {
     name,

--- a/packages/nest/src/make-enum.ts
+++ b/packages/nest/src/make-enum.ts
@@ -1,5 +1,5 @@
 import { registerEnumType } from '@nestjs/graphql';
-import { cleanJoin, nonEnumerable, setHas } from '@seedcompany/common';
+import { cleanJoin, mapKeys, nonEnumerable } from '@seedcompany/common';
 import { inspect, InspectOptionsStylized } from 'util';
 
 export type EnumType<Enum> = Enum extends MadeEnum<infer Values, any, any>
@@ -81,6 +81,7 @@ export const makeEnum = <
     (value: EnumValueDeclarationShape): EnumValueDeclarationObjectShape =>
       typeof value === 'string' ? { value } : value,
   );
+  const entryMap = mapKeys.fromList(entries, (e) => e.value).asMap;
 
   const object = Object.fromEntries(entries.map((v) => [v.value, v.value]));
 
@@ -91,7 +92,14 @@ export const makeEnum = <
     entries,
     [Symbol.iterator]: () => values.values(),
     // @ts-expect-error Ignoring generics for implementation.
-    has: (value: string) => setHas(values, value),
+    has: (value: string) => entryMap.has(value),
+    entry: (value: string) => {
+      const entry = entryMap.get(value);
+      if (!entry) {
+        throw new Error(`${name ?? 'Enum'} does not have member: "${value}"`);
+      }
+      return entry;
+    },
     [inspect.custom]: (
       depth: number,
       options: InspectOptionsStylized,
@@ -191,6 +199,7 @@ type NormalizedValueDeclaration<Declaration extends EnumValueDeclarationShape> =
 interface EnumHelpers<Values extends string, ValueDeclaration> {
   readonly values: ReadonlySet<Values>;
   readonly entries: ReadonlyArray<Readonly<ValueDeclaration>>;
+  readonly entry: (value: Values) => Readonly<ValueDeclaration>;
   readonly has: <In extends string>(
     value: In & {},
   ) => value is In & Values & {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4392,7 +4392,9 @@ __metadata:
     "@nestjs/graphql": "npm:^12"
     "@nestjs/testing": "npm:^10"
     "@seedcompany/common": "npm:>0.3 <1"
+    change-case: "npm:^5.4.4"
     rxjs: "npm:^7.8.1"
+    title-case: "npm:^4.3.1"
   peerDependencies:
     "@nestjs/common": ^10
     "@nestjs/core": ^10
@@ -6113,6 +6115,13 @@ __metadata:
     escape-string-regexp: "npm:^1.0.5"
     supports-color: "npm:^5.3.0"
   checksum: 10c0/e6543f02ec877732e3a2d1c3c3323ddb4d39fbab687c23f526e25bd4c6a9bf3b83a696e8c769d078e04e5754921648f7821b2a2acfd16c550435fd630026e073
+  languageName: node
+  linkType: hard
+
+"change-case@npm:^5.4.4":
+  version: 5.4.4
+  resolution: "change-case@npm:5.4.4"
+  checksum: 10c0/2a9c2b9c9ad6ab2491105aaf506db1a9acaf543a18967798dcce20926c6a173aa63266cb6189f3086e3c14bf7ae1f8ea4f96ecc466fcd582310efa00372f3734
   languageName: node
   linkType: hard
 
@@ -14337,6 +14346,13 @@ __metadata:
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: 10c0/4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
+  languageName: node
+  linkType: hard
+
+"title-case@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "title-case@npm:4.3.1"
+  checksum: 10c0/10bb67f3ae5cf4043b4050f5c4b3ae7fdaeef6c55bcb646d08a3567d4233f02d10f3ea55add7d8dbf55e1a320b49b79cb0b5d4ce39701a500de62cc8860d9bc8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- `Enum.entry(value): Entry`
- `Enum.entry(X).label`
   Cord uses lodash to generate human labels.
   I didn't want to depend on that here though, so I'm using `change-case` & `title-case` instead.
  They are much smaller & specific in scope, but they do require ESM.
- Flip `MadeEnum` `Extra` positional generic 
	This allows declaring extra entry declarations easier,
	by making it the second arg instead of third.
	
	This `Extra` generic really has nothing to do with the enum functionality,
	it's just extra statics.
	The type could be written as:
	```ts
	MadeEnum<Status> & { <Extras> }
	```
	
	I decided to keep the generic though as that helps TS infer how to
	emit the type.
	```ts
	const X = makeEnum(...); // X is `MadeEnum<...>`
	```
	As opposed to some obtuse object literal shape.
- Fix enum type assignability to looser shape
	```ts
	// Given
	let Color: MadeEnum<'red' | 'blue'>;
	let AnEnum: MadeEnum<string>;
	
	// Now
	AnEnum = Color;
	```
	Two changes to make this compatible.
	
	First, disallow direct access to member values when referencing generically.
	
	Without this change `Color` can't be assigned to `AnEnum`,
	because the TS defines the member values as an index: `{ [x: string]: string }`.
	So since one has an index accessor and one doesn't, making them incompatible.
	
	Secondly, The `entry()` arg type change also allows them to be compatible.
	Without it TS thinks something like `entry()` fn accepting any `string` is not
	compatible with `entry()` fn only accepting `'red' | 'blue'`.
	Using another generic at the function level somehow works around this,
	while still maintaining all the strictness.