### PR TITLE
feat(nest): metadata decorator

### DIFF
--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -12,7 +12,9 @@
     "@nestjs/graphql": "^12",
     "@seedcompany/common": ">0.3 <1",
     "change-case": "^5.4.4",
-    "title-case": "^4.3.1"
+    "title-case": "^4.3.1",
+    "type-fest": "^4.26.1",
+    "uuid": "^11.0.0-0"
   },
   "peerDependencies": {
     "@nestjs/common": "^10",
@@ -23,7 +25,7 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc",
-    "test": "jest --passWithNoTests"
+    "test": "jest"
   },
   "devDependencies": {
     "@nestjs/testing": "^10",

--- a/packages/nest/src/index.ts
+++ b/packages/nest/src/index.ts
@@ -1,2 +1,3 @@
 export * from './make-enum';
 export * from './repl';
+export * from './metadata-decorator';

--- a/packages/nest/src/metadata-decorator.test.ts
+++ b/packages/nest/src/metadata-decorator.test.ts
@@ -1,0 +1,538 @@
+/* eslint @typescript-eslint/ban-ts-comment: ["error", minimumDescriptionLength: 0] */
+import { describe, expect, test } from '@jest/globals';
+import * as Nest from '@nestjs/common';
+import * as NestConstants from '@nestjs/common/constants.js';
+import { createMetadataDecorator } from './metadata-decorator';
+
+test('TS: Get/Set based on configured types', () => {
+  // Not executed to avoid affecting coverage.
+  function _assert() {
+    const Any = createMetadataDecorator();
+    const Class = createMetadataDecorator({
+      types: ['class'],
+    });
+    const Property = createMetadataDecorator({
+      types: ['property'],
+    });
+    const Method = createMetadataDecorator({
+      types: ['method'],
+    });
+    const Parameter = createMetadataDecorator({
+      types: ['parameter'],
+    });
+
+    @Any()
+    @Class()
+    // @ts-expect-error
+    @Property()
+    // @ts-expect-error
+    @Method()
+    // @ts-expect-error
+    @Parameter()
+    class T {
+      @Any()
+      // @ts-expect-error
+      @Class()
+      @Property()
+      // @ts-expect-error
+      @Method()
+      // @ts-expect-error
+      @Parameter()
+      prop: string;
+
+      @Any()
+      // @ts-expect-error
+      @Class()
+      // @ts-expect-error
+      @Property()
+      @Method()
+      // @ts-expect-error
+      @Parameter()
+      method(
+        @Any()
+        // @ts-expect-error
+        @Class()
+        // @ts-expect-error
+        @Property()
+        // @ts-expect-error
+        @Method()
+        @Parameter()
+        _arg: string,
+      ) {
+        return;
+      }
+    }
+
+    Any.get(T);
+    Any.get(T, 'prop');
+    Any.get(T, 'method');
+    Any.get(T, 'method', 0);
+
+    Class.get(T);
+    // @ts-expect-error
+    Class.get(T, 'prop');
+    // @ts-expect-error
+    Class.get(T, 'method');
+    // @ts-expect-error
+    Class.get(T, 'method', 0);
+
+    // @ts-expect-error
+    Property.get(T);
+    Property.get(T, 'prop');
+    // @ts-expect-error
+    Property.get(T, 'method');
+    // @ts-expect-error
+    Property.get(T, 'method', 0);
+
+    // @ts-expect-error
+    Method.get(T);
+    // @ts-expect-error
+    Method.get(T, 'prop');
+    Method.get(T, 'method');
+    // @ts-expect-error
+    Method.get(T, 'method', 0);
+
+    // @ts-expect-error
+    Parameter.get(T);
+    // @ts-expect-error
+    Parameter.get(T, 'prop');
+    // @ts-expect-error
+    Parameter.get(T, 'method');
+    Parameter.get(T, 'method', 0);
+    // @ts-expect-error built-in types allow this for some reason. be sure we block.
+    Parameter.get(T, undefined, 0);
+
+    // @ts-expect-error literal failure is marked
+    Any.get(T, 'nope');
+    // generic string is allowed
+    Any.get(T, 'nope' as string);
+    // @ts-expect-error literal failure is marked
+    Any.get(T, 'nope', 0);
+    // generic string is allowed
+    Any.get(T, 'nope' as string, 0);
+    // @ts-expect-error literal failure is marked
+    Property.get(T, 'nope');
+    // generic string is allowed
+    Property.get(T, 'nope' as string);
+    // @ts-expect-error literal failure is marked
+    Method.get(T, 'nope');
+    // generic string is allowed
+    Method.get(T, 'nope' as string);
+    // @ts-expect-error literal failure is marked
+    Parameter.get(T, 'nope', 0);
+    // generic string is allowed
+    Parameter.get(T, 'nope' as string, 0);
+  }
+});
+
+test('TS: Setter Defines input args & output type', () => {
+  const Name = createMetadataDecorator({
+    setter: (name: string) => name.toUpperCase(),
+  });
+  const Mark = createMetadataDecorator();
+
+  class T {}
+
+  function _typeAssertions() {
+    // @ts-expect-error
+    Name();
+    // @ts-expect-error
+    Name(false);
+    // @ts-expect-error
+    Mark(false);
+    // @ts-expect-error
+    Name('', false);
+    // @ts-expect-error
+    Mark(false, false);
+
+    // @ts-expect-error
+    Name.get(T).toLocaleLowerCase();
+    Name.get(T)?.toLocaleLowerCase();
+
+    // @ts-expect-error
+    const _nope: false = Mark.get(T);
+    const _yes: true | undefined = Mark.get(T);
+  }
+
+  expect(Name.get(T)).toBeUndefined();
+  Name('hello')(T);
+  expect(Name.get(T)).toBe('HELLO');
+  Name('world')(T);
+  expect(Name.get(T)).toBe('WORLD');
+
+  Mark()(T);
+  expect(Mark.get(T)).toBe(true);
+});
+
+describe('Get/Set', () => {
+  const Word = createMetadataDecorator({
+    setter: (word: string) => word,
+  });
+
+  @Word('hello class')
+  class Y {
+    @Word('hello prop')
+    prop: string;
+
+    @Word('hello method')
+    method(
+      @Word('hello param 0')
+      _param: string,
+    ) {
+      return;
+    }
+  }
+
+  test('As Class', () => {
+    expect(Word.get(Y)).toBe('hello class');
+  });
+
+  test('As Prop', () => {
+    expect(Word.get(Y, 'prop')).toBe('hello prop');
+  });
+
+  test('As Method', () => {
+    expect(Word.get(Y, 'method')).toBe('hello method');
+    const instance = new Y();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(Word.get(instance.method)).toBe('hello method');
+  });
+
+  test('As Parameter', () => {
+    expect(Word.get(Y, 'method', 0)).toBe('hello param 0');
+  });
+});
+
+describe('Inheritance', () => {
+  const Marked = createMetadataDecorator({
+    setter: (marked = true) => marked,
+  });
+
+  class Person {
+    @Marked()
+    name: string;
+    @Marked()
+    age: number;
+  }
+  class Hero extends Person {
+    @Marked(false)
+    declare age: number;
+  }
+
+  test('Defaults to inherited', () => {
+    expect(Marked.get(Hero, 'name')).toBe(true);
+  });
+  test('getOwn ignores inheritance', () => {
+    expect(Marked.getOwn(Hero, 'name')).toBeUndefined();
+  });
+  test('Own value overrides inherited value', () => {
+    expect(Marked.get(Hero, 'age')).toBe(false);
+    expect(Marked.getOwn(Hero, 'age')).toBe(false);
+  });
+});
+
+describe('Merging', () => {
+  describe('As Class', () => {
+    test('Overrides by default', () => {
+      const Label = createMetadataDecorator({
+        setter: (label: string) => [label],
+      });
+
+      @Label('Foo')
+      @Label('Bar')
+      class A {}
+
+      expect(Label.get(A)).toEqual(['Foo']);
+    });
+
+    test('Merges with own previous value & includes inherited', () => {
+      const Label = createMetadataDecorator({
+        setter: (label: string) => ({ labels: [label] }),
+        merge: ({ next, previous, inherited, type }) => ({
+          type,
+          labels: [...next.labels, ...(previous?.labels ?? [])],
+          inherited,
+        }),
+      });
+
+      @Label('Foo')
+      @Label('Bar')
+      class A {}
+      @Label('Baz')
+      @Label('Yo')
+      class B extends A {}
+
+      expect(Label.get(A)).toEqual({
+        type: 'class',
+        labels: ['Foo', 'Bar'],
+        inherited: undefined,
+      });
+      expect(Label.get(B)).toEqual({
+        type: 'class',
+        labels: ['Baz', 'Yo'],
+        inherited: {
+          type: 'class',
+          labels: ['Foo', 'Bar'],
+          inherited: undefined,
+        },
+      });
+    });
+  });
+
+  describe('As Property', () => {
+    test('Overrides by default', () => {
+      const Label = createMetadataDecorator({
+        setter: (label: string) => [label],
+      });
+
+      class A {
+        @Label('Foo')
+        @Label('Bar')
+        prop: string;
+      }
+
+      expect(Label.get(A, 'prop')).toEqual(['Foo']);
+    });
+
+    test('Merges with own previous value & includes inherited', () => {
+      const Label = createMetadataDecorator({
+        setter: (label: string) => ({ labels: [label] }),
+        merge: ({ next, previous, inherited, type }) => ({
+          type,
+          labels: [...next.labels, ...(previous?.labels ?? [])],
+          inherited,
+        }),
+      });
+
+      class A {
+        @Label('Foo')
+        @Label('Bar')
+        prop: string;
+      }
+      class B extends A {
+        @Label('Baz')
+        @Label('Yo')
+        declare prop: string;
+      }
+
+      expect(Label.get(A, 'prop')).toEqual({
+        type: 'property',
+        labels: ['Foo', 'Bar'],
+        inherited: undefined,
+      });
+      expect(Label.get(B, 'prop')).toEqual({
+        type: 'property',
+        labels: ['Baz', 'Yo'],
+        inherited: {
+          type: 'property',
+          labels: ['Foo', 'Bar'],
+          inherited: undefined,
+        },
+      });
+    });
+  });
+
+  describe('As Method', () => {
+    test('Overrides by default', () => {
+      const Label = createMetadataDecorator({
+        setter: (label: string) => [label],
+      });
+
+      class A {
+        @Label('Foo')
+        @Label('Bar')
+        method() {
+          return;
+        }
+      }
+
+      expect(Label.get(A, 'method')).toEqual(['Foo']);
+    });
+
+    test('Merges with own previous value & includes inherited', () => {
+      const Label = createMetadataDecorator({
+        setter: (label: string) => ({ labels: [label] }),
+        merge: ({ next, previous, inherited, type }) => ({
+          type,
+          labels: [...next.labels, ...(previous?.labels ?? [])],
+          inherited,
+        }),
+      });
+
+      class A {
+        @Label('Foo')
+        @Label('Bar')
+        method() {
+          return;
+        }
+      }
+      class B extends A {
+        @Label('Baz')
+        @Label('Yo')
+        method() {
+          return;
+        }
+      }
+
+      expect(Label.get(A, 'method')).toEqual({
+        type: 'method',
+        labels: ['Foo', 'Bar'],
+        inherited: undefined,
+      });
+      expect(Label.get(B, 'method')).toEqual({
+        type: 'method',
+        labels: ['Baz', 'Yo'],
+        inherited: {
+          type: 'method',
+          labels: ['Foo', 'Bar'],
+          inherited: undefined,
+        },
+      });
+    });
+  });
+
+  describe('As Parameter', () => {
+    test('Overrides by default', () => {
+      const Label = createMetadataDecorator({
+        setter: (label: string) => [label],
+      });
+
+      class A {
+        method(
+          @Label('Foo')
+          @Label('Bar')
+          _param: string,
+        ) {
+          return;
+        }
+      }
+
+      expect(Label.get(A, 'method', 0)).toEqual(['Foo']);
+    });
+
+    test('Merges with own previous value & includes inherited', () => {
+      const Label = createMetadataDecorator({
+        setter: (label: string) => ({ labels: [label] }),
+        merge: ({ next, previous, inherited, type }) => ({
+          type,
+          labels: [...next.labels, ...(previous?.labels ?? [])],
+          inherited,
+        }),
+      });
+
+      class A {
+        method(
+          @Label('Foo')
+          @Label('Bar')
+          _param: string,
+        ) {
+          return;
+        }
+      }
+      class B extends A {
+        method(
+          @Label('Baz')
+          @Label('Yo')
+          _param: string,
+        ) {
+          return;
+        }
+      }
+
+      expect(Label.get(A, 'method', 0)).toEqual({
+        type: 'parameter',
+        labels: ['Foo', 'Bar'],
+        inherited: undefined,
+      });
+      expect(Label.get(B, 'method', 0)).toEqual({
+        type: 'parameter',
+        labels: ['Baz', 'Yo'],
+        inherited: {
+          type: 'parameter',
+          labels: ['Foo', 'Bar'],
+          inherited: undefined,
+        },
+      });
+    });
+  });
+});
+
+// Trying to enforce the principle of not being magical.
+// A fallback for "prop to class level" creates a multi-inheritance situation.
+// E.g., If a prop doesn't have its own value, we don't know
+// if we should fall back to the own class value or the inherited prop value.
+// Thus, we let the caller decide that their own usage of `get` vs `getOwn` and null-coalescing.
+test('Multi-Level fall backs are manual', () => {
+  const Word = createMetadataDecorator({
+    setter: (name: string) => name,
+  });
+
+  @Word('Cls')
+  class Person {
+    @Word('name')
+    name: string;
+    prop: string;
+  }
+
+  // If looking to fall back to class level, you need to do it yourself
+  expect(Word.get(Person, 'prop')).toBeUndefined();
+  expect(Word.get(Person, 'prop') ?? Word.get(Person)).toBe('Cls');
+
+  // Confirm override is possible with ?? expression.
+  expect(Word.get(Person, 'name')).toBe('name');
+  expect(Word.get(Person, 'name') ?? Word.get(Person)).toBe('name');
+});
+
+describe('Compatibility with NestJS decorators using reflect-metadata', () => {
+  describe('As Class', () => {
+    const ControllerWatermark = createMetadataDecorator({
+      key: NestConstants.CONTROLLER_WATERMARK,
+    });
+
+    test('get', () => {
+      @Nest.Controller()
+      class T {}
+      expect(ControllerWatermark.get(T)).toBe(true);
+    });
+    test('set', () => {
+      @ControllerWatermark()
+      class T {}
+      const value = Reflect.getMetadata(ControllerWatermark.KEY, T);
+      expect(value).toBe(true);
+    });
+  });
+
+  describe('As Method - they set on descriptors', () => {
+    const OurHeader = createMetadataDecorator({
+      key: NestConstants.HEADERS_METADATA,
+      setter: (name: string, value: string | (() => string)) => [
+        { name, value },
+      ],
+      merge: ({ next, previous }) => [...(previous ?? []), ...next],
+    });
+
+    test('get', () => {
+      class T {
+        @Nest.Header('color', 'red')
+        method() {
+          return;
+        }
+      }
+      expect(OurHeader.get(T, 'method')).toEqual([
+        { name: 'color', value: 'red' },
+      ]);
+    });
+    test('set', () => {
+      class T {
+        @OurHeader('color', 'red')
+        method() {
+          return;
+        }
+      }
+      const instance = new T();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const value = Reflect.getMetadata(OurHeader.KEY, instance.method);
+      expect(value).toEqual([{ name: 'color', value: 'red' }]);
+    });
+  });
+});

--- a/packages/nest/src/metadata-decorator.ts
+++ b/packages/nest/src/metadata-decorator.ts
@@ -1,0 +1,351 @@
+import type { ArrayItem, FnLike } from '@seedcompany/common';
+import type {
+  AbstractClass,
+  ConditionalExcept,
+  ConditionalKeys,
+  StringKeyOf,
+  UnionToIntersection,
+} from 'type-fest';
+import * as uuid from 'uuid';
+import 'reflect-metadata';
+
+const { defineMetadata } = Reflect;
+
+export type MetadataDecorator<
+  Types extends DecoratorTypes,
+  ArgsIn extends unknown[],
+  ValueStored,
+> = ((...args: ArgsIn) => DecoratorForTypes<Types>) & {
+  /**
+   * The given or created metadata key used in storage.
+   */
+  KEY: string | symbol;
+  /**
+   * Get the value stored, if any, from the given target.
+   * This will pull from inherited targets as well if the given target doesn't have a value stored.
+   */
+  get: GetterForTypes<Types, ValueStored | undefined>;
+  /**
+   * Get the value stored, if any, from the given target.
+   * Inherited values are not considered with this getter.
+   */
+  getOwn: GetterForTypes<Types, ValueStored | undefined>;
+};
+
+export interface MetadataDecoratorOptions<
+  Types extends DecoratorTypes,
+  ArgsIn extends unknown[],
+  ValueStored,
+> {
+  /**
+   * The metadata key that will be used in storage
+   * Defaults to a UUID.
+   */
+  key?: string | symbol;
+  /**
+   * Limit the decorator to certain locations/usages.
+   */
+  types?: readonly Types[];
+  /**
+   * Defines the arguments required when calling the decorator
+   * and how those are converted to the stored value.
+   */
+  setter?: (...args: ArgsIn) => ValueStored;
+  /**
+   * A function to declare how a new value should be stored.
+   * Without this, the default behavior is to overwrite the former value and ignore the inherited.
+   * This allows defining how previous, inherited values are considered.
+   * For example, this could enable lists to be merged.
+   */
+  merge?: (args: MergeArgs<ValueStored>) => ValueStored;
+}
+
+interface MergeArgs<ValueStored> {
+  /**
+   * The new value from this decorator call.
+   */
+  next: ValueStored;
+  /**
+   * The previous value stored, if any, from this current target.
+   * Inherited values aren't given here.
+   */
+  previous: ValueStored | undefined;
+  /**
+   * The inherited value stored, if any, from the parent target.
+   * The current target is never considered for this.
+   */
+  inherited: ValueStored | undefined;
+  /**
+   * The decorator location type where the merge is happening.
+   * Not sure if this is useful.
+   * Was attempting to allow some sort of fallback logic, but
+   * so far it hasn't panned out.
+   */
+  type: DecoratorTypes;
+}
+
+/**
+ * Create a decorator that stores metadata.
+ * This is a wrapper around the reflect-metadata library that
+ * provides strict types and an easy-to-use API for any kind of decorator.
+ *
+ * @example Simple marker tag
+ * ```ts
+ * const Tag = createMetadataDecorator();
+ *
+ * @Tag()
+ * class Foo {}
+ *
+ * Tag.get(Foo) // => true | undefined
+ * // === true
+ * ```
+ *
+ * @example Add data to be stored
+ * ```ts
+ * const Tag = createMetadataDecorator({
+ *   // This function declares the args that are exposed to the decorator
+ *   // And the return type declares the stored value shape
+ *   setter: (name: string, opts?: { age?: number }) => ({
+ *     name,
+ *     age: opts?.age,
+ *   })
+ * });
+ *
+ * @Tag('Bob', { age: 50 })
+ * class Foo {}
+ *
+ * Tag.get(Foo) // => { name: string, age?: number } | undefined
+ * // === { name: 'Bob', age: 50 }
+ * ```
+ *
+ * @example Labels with merging
+ * ```ts
+ * const Label = createMetadataDecorator({
+ *   type: ['class'] // only allow for classes
+ *   setter: (label: string) => [label],
+ *   merge: ({ next, previous }) => [...previous ?? [], ...next],
+ * });
+ *
+ * @Label('A')
+ * @Label('B')
+ * class Foo {}
+ *
+ * Label.get(Foo) // => string[] | undefined
+ * // === ['B', 'A']
+ * ```
+ *
+ * # Prior Art
+ *
+ * This is similar to {@link import('@nestjs/core').Reflector NestJS' Reflector}.
+ * But it doesn't have as much flexibility in what types of decoration are allowed, nor
+ * what types of input args are allowed, nor values stored.
+ * The Reflector class doesn't correctly type that values could be missing/`undefined`.
+ */
+export const createMetadataDecorator = <
+  ArgsIn extends unknown[] = [],
+  ValueStored = true,
+  const Types extends DecoratorTypes = DecoratorTypes,
+>(
+  options: MetadataDecoratorOptions<Types, ArgsIn, ValueStored> = {},
+): MetadataDecorator<Types, ArgsIn, ValueStored> => {
+  const {
+    key: keyIn,
+    // types: typesIn,
+    setter = () => true as ValueStored,
+    merge,
+  } = options;
+  const id = keyIn ?? uuid.v7();
+
+  const makeGetter =
+    (getMetadata: typeof Reflect.getMetadata) =>
+    (
+      target: AbstractClass<any>,
+      property?: string | symbol,
+      index?: number,
+    ): ValueStored | undefined => {
+      // ParameterDecorator
+      if (typeof index === 'number') {
+        const val = getMetadata(id, target, `${String(property)}:${index}`);
+        return val;
+      }
+
+      // MethodDecorator / PropertyDecorator
+      if (property) {
+        let val = getMetadata(id, target, property);
+        if (val !== undefined) {
+          return val;
+        }
+        // Fall back to descriptor
+        // aka: get(new Class().method)
+        const descriptor = Object.getOwnPropertyDescriptor(
+          target.prototype,
+          property,
+        );
+        val = descriptor ? getMetadata(id, descriptor.value) : undefined;
+        return val;
+      }
+
+      // ClassDecorator
+      const val = getMetadata(id, target);
+      return val;
+    };
+
+  const getOwn = makeGetter(Reflect.getOwnMetadata);
+  const get = makeGetter(Reflect.getMetadata);
+
+  const decorator = (
+    ...args: ArgsIn
+  ):
+    | ClassDecorator
+    | MethodDecorator
+    | PropertyDecorator
+    | ParameterDecorator => {
+    const value = setter(...args);
+    return (
+      target: object,
+      property?: string | symbol,
+      indexOrDescriptor?: number | TypedPropertyDescriptor<any>,
+    ) => {
+      let next = value;
+
+      // ClassDecorator
+      if (!property && indexOrDescriptor == null) {
+        if (merge) {
+          const previous = getOwn(target as AbstractClass<any>);
+          const inherited = get(Object.getPrototypeOf(target));
+          next = merge({
+            next,
+            previous,
+            inherited,
+            type: 'class',
+          });
+        }
+        defineMetadata(id, next, target);
+        return;
+      }
+
+      const staticCls = target.constructor as AbstractClass<any>;
+      let parentCls = Object.getPrototypeOf(staticCls) as
+        | AbstractClass<any>
+        | undefined;
+      // prototype doesn't exist when the staticCls doesn't extend anything.
+      parentCls = parentCls?.prototype ? parentCls : undefined;
+      const index =
+        typeof indexOrDescriptor === 'number' ? indexOrDescriptor : undefined;
+      const descriptor =
+        indexOrDescriptor && index === undefined
+          ? (indexOrDescriptor as TypedPropertyDescriptor<any>)
+          : undefined;
+
+      // ParameterDecorator
+      if (index != null) {
+        if (merge) {
+          const previous = getOwn(staticCls, property, index);
+          const inherited = parentCls
+            ? get(parentCls, property, index)
+            : undefined;
+          next = merge({
+            next,
+            previous,
+            inherited,
+            type: 'parameter',
+          });
+        }
+        defineMetadata(id, next, staticCls, `${String(property)}:${index}`);
+        return;
+      }
+
+      // MethodDecorator
+      if (descriptor) {
+        if (merge) {
+          const previous = getOwn(staticCls, property);
+          const inherited = parentCls ? get(parentCls, property) : undefined;
+          next = merge({
+            next,
+            previous,
+            inherited,
+            type: 'method',
+          });
+        }
+        // Allow access via: get(Class, 'method')
+        defineMetadata(id, next, staticCls, property!);
+        // Allow access via: get(new Class().method)
+        // NestJS does this
+        defineMetadata(id, next, descriptor.value);
+        return descriptor;
+      }
+
+      // PropertyDecorator
+      if (property) {
+        if (merge) {
+          const previous = getOwn(staticCls, property);
+          const inherited = parentCls ? get(parentCls, property) : undefined;
+          next = merge({
+            next,
+            previous,
+            inherited,
+            type: 'property',
+          });
+        }
+        defineMetadata(id, next, staticCls, property);
+        return;
+      }
+
+      /* istanbul ignore next */
+      throw new Error('Invalid decorator usage');
+    };
+  };
+
+  return Object.assign(decorator, { KEY: id, get, getOwn }) as any;
+};
+
+const allDecoratorTypes = ['class', 'property', 'method', 'parameter'] as const;
+type DecoratorTypes = ArrayItem<typeof allDecoratorTypes>;
+
+type DecoratorForTypes<Types extends DecoratorTypes> = UnionToIntersection<
+  | (Types extends 'class' ? ClassDecorator : never)
+  | (Types extends 'property' ? PropertyDecorator : never)
+  | (Types extends 'method' ? MethodDecorator : never)
+  | (Types extends 'parameter' ? ParameterDecorator : never)
+>;
+type GetterForTypes<Types extends DecoratorTypes, Return> = UnionToIntersection<
+  | (Types extends 'class' ? ClassGetter<Return> : never)
+  | (Types extends 'method' ? MethodGetter<Return> : never)
+  | (Types extends 'property' ? PropertyGetter<Return> : never)
+  | (Types extends 'parameter' ? ParameterGetter<Return> : never)
+>;
+
+type ClassGetter<Return> = <T>(target: AbstractClass<T>) => Return;
+interface MethodGetter<Return> {
+  <T, const K extends string>(
+    target: AbstractClass<T>,
+    methodName: (string extends K ? K : ConditionalKeys<T, FnLike>) | symbol,
+  ): Return;
+  (method: FnLike): Return;
+}
+type PropertyGetter<Return> = <T, const K extends string>(
+  target: AbstractClass<T>,
+  methodName:
+    | (string extends K ? K : StringKeyOf<ConditionalExcept<T, FnLike>>)
+    | symbol,
+) => Return;
+type ParameterGetter<Return> = <T, const K extends string>(
+  target: AbstractClass<T>,
+  methodName: (string extends K ? K : ConditionalKeys<T, FnLike>) | symbol,
+  parameterIndex: number,
+) => Return;
+
+type PropertyDecorator = (
+  target: object,
+  propertyKey: string | symbol,
+  // I added this arg.
+  // It avoids this decorator mistakenly matching / being compatible with MethodDecorator
+  nope?: never,
+) => void;
+
+type ParameterDecorator = (
+  target: object,
+  // I changed to be non-nullable. I'm not sure why TS has this as nullable.
+  methodName: string | symbol,
+  parameterIndex: number,
+) => void;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4071,6 +4071,8 @@ __metadata:
     reflect-metadata: "npm:^0.1.12"
     rxjs: "npm:^7.8.1"
     title-case: "npm:^4.3.1"
+    type-fest: "npm:^4.26.1"
+    uuid: "npm:^11.0.0-0"
   peerDependencies:
     "@nestjs/common": ^10
     "@nestjs/core": ^10
@@ -15124,6 +15126,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 10c0/1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^11.0.0-0":
+  version: 11.0.0-0
+  resolution: "uuid@npm:11.0.0-0"
+  bin:
+    uuid: dist/esm/bin/uuid
+  checksum: 10c0/04415a6b32b82bfcacf1dabc084ae0c64beea9700dfb716bdea4b9f32a2f247f316bd7ec6619813b37fbb00685eeb76efef391d610091413e3a1d53fa13de570
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This abstracts the `reflect-metadata` library to provide strictly typed decorators with an easier to use API.

## Simple marker tag
```ts
const Tag = createMetadataDecorator();

@Tag()
class Foo {}

Tag.get(Foo) // => true | undefined
// === true
```

## Add data to be stored
```ts
const Tag = createMetadataDecorator({
  // This function declares the args that are exposed to the decorator
  // And the return type declares the stored value shape
  setter: (name: string, opts?: { age?: number }) => ({
    name,
    age: opts?.age,
  })
});

@Tag('Bob', { age: 50 })
class Foo {}

Tag.get(Foo) // => { name: string, age?: number } | undefined
// === { name: 'Bob', age: 50 }
```

## Labels with merging
```ts
const Label = createMetadataDecorator({
  type: ['class'] // only allow for classes
  setter: (label: string) => [label],
  merge: ({ next, previous }) => [...previous ?? [], ...next],
});

@Label('A')
@Label('B')
class Foo {}

Label.get(Foo) // => string[] | undefined
// === ['B', 'A']
```