### PR TITLE
feat(common): patchMethod

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -13,6 +13,9 @@
       "optional": true
     }
   },
+  "dependencies": {
+    "type-fest": "^4.37.0"
+  },
   "devDependencies": {
     "@types/luxon": "^3.2.0",
     "luxon": "^3.3.0"

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -14,6 +14,7 @@ export * from './many.js';
 export * from './map-of.js';
 export * from './map-to.js';
 export * from './non-enumerable.js';
+export * from './patch-method.js';
 export * from './set-has.js';
 export * from './set-of.js';
 export * from './simple-switch.js';

--- a/packages/common/src/patch-method.ts
+++ b/packages/common/src/patch-method.ts
@@ -1,0 +1,62 @@
+import type { ConditionalKeys } from 'type-fest';
+import type { FnLike } from './types.js';
+
+/**
+ * This is a helper to monkey patch methods (probably from libraries) to adjust logic.
+ *
+ * This replaces a method/function on an object with another.
+ * The original function is given to the replacer callback so that it can be called before/after patching logic is applied.
+ *
+ * A caveat to this is it doesn't support generics on the function.
+ *
+ * The original function is given with `this` bound to the object being patched.
+ * This allows it to be called directly without having to use {@link Function.call}/{@link Function.apply} to forward `this`.
+ *
+ * The replacer callback and the current function are also called with `this` bound to the object.
+ * This allows `this` to be used (in regular functions, not arrow functions) as expected with class methods.
+ *
+ * @example
+ * ```ts
+ * patchMethod(FooClass.prototype, 'foo', (orig) => (...args) => {
+ *   // {business logic to adjust args}
+ *   const result = orig(...args);
+ *   // {business logic to adjust result}
+ *   return result;
+ * });
+ * ```
+ *
+ * The goal of this is to reduce the boilerplate for this common concept for us.
+ * Without this helper, the above example would be:
+ * ```ts
+ * const origFoo = FooClass.prototype.foo;
+ * FooClass.prototype.foo = function foo(...args) {
+ *   // {business logic to adjust args}
+ *   const result = origFoo.call(this, ...args);
+ *   // {business logic to adjust result}
+ *   return result;
+ * };
+ * ```
+ */
+export function patchMethod<
+  T,
+  const K extends ConditionalKeys<T, Fn>,
+  Fn extends T[K] & FnLike = T[K] extends FnLike ? T[K] : never,
+>(
+  obj: T,
+  name: K & string,
+  replacer: (
+    this: T,
+    prev: (this: void, ...args: Parameters<Fn>) => ReturnType<Fn>,
+  ) => (this: T, ...args: Parameters<Fn>) => ReturnType<Fn>,
+) {
+  const prev = obj[name] as Fn;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!prev) {
+    throw new Error(`Method ${name} does not exist on ${String(obj)}`);
+  }
+  (obj as any)[name] = {
+    [name]: function (this: T, ...args: Parameters<Fn>): ReturnType<Fn> {
+      return replacer.call(this, prev.bind(this)).call(this, ...args);
+    } as Fn,
+  }[name];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3752,6 +3752,7 @@ __metadata:
   dependencies:
     "@types/luxon": "npm:^3.2.0"
     luxon: "npm:^3.3.0"
+    type-fest: "npm:^4.37.0"
   peerDependencies:
     luxon: ^3.3.0
   peerDependenciesMeta:
@@ -13482,10 +13483,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^4.26.1":
-  version: 4.26.1
-  resolution: "type-fest@npm:4.26.1"
-  checksum: 10c0/d2719ff8d380befe8a3c61068f37f28d6fa2849fd140c5d2f0f143099e371da6856aad7c97e56b83329d45bfe504afe9fd936a7cff600cc0d46aa9ffb008d6c6
+"type-fest@npm:^4.26.1, type-fest@npm:^4.37.0":
+  version: 4.37.0
+  resolution: "type-fest@npm:4.37.0"
+  checksum: 10c0/5bad189f66fbe3431e5d36befa08cab6010e56be68b7467530b7ef94c3cf81ef775a8ac3047c8bbda4dd3159929285870357498d7bc1df062714f9c5c3a84926
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is a helper to monkey patch methods (probably from libraries) to adjust logic.

```ts
patchMethod(FooClass.prototype, 'foo', (orig) => (...args) => {
  // {business logic to adjust args}
  const result = orig(...args);
  // {business logic to adjust result}
  return result;
});
```