### PR TITLE
Common: isObjectLike / isPlainObject / magic method setters / etc

### DIFF
--- a/packages/common/src/define-class-prop.ts
+++ b/packages/common/src/define-class-prop.ts
@@ -1,0 +1,17 @@
+/**
+ * @internal
+ */
+export const defineClassProp = <T extends { prototype: unknown } | object>(
+  classOrObject: T,
+  key: string | symbol,
+  descriptor: PropertyDescriptor,
+): T => {
+  const proto = Object.hasOwn(classOrObject, 'prototype')
+    ? (classOrObject as { prototype: unknown }).prototype
+    : classOrObject;
+  Object.defineProperty(proto, key, {
+    configurable: true,
+    ...descriptor,
+  });
+  return classOrObject;
+};

--- a/packages/common/src/has-ctor-proto.ts
+++ b/packages/common/src/has-ctor-proto.ts
@@ -1,0 +1,68 @@
+/**
+ * Does the object have a (non-base object) constructor?
+ *
+ * This doesn't care if the object has a non-base object prototype.
+ *
+ * ## Input Matrix
+ *
+ * | Input                 | Constructor/Prototype | `hasCtor` | `hasProto` |
+ * |-----------------------|-----------------------|-----------|------------|
+ * | `new Foo()`           | `Foo`                 | `true`    | `true`     |
+ * | `{}`                  | `Object`              | `false`   | `false`    |
+ * | `Object.create(foo)`  | `Foo`                 | `true`    | `true`     |
+ * | `Object.create({})`   | `Object`              | `false`   | `true`     |
+ * | `Object.create(null)` | `null`                | `false`   | `false`    |
+ * | `""`                  | `String`              | `true`    | `true`     |
+ * | `[]`                  | `Array`               | `true`    | `true`     |
+ *
+ * A couple of notes:
+ * - Primitives & builtin objects have non-object constructors.
+ * - When using `Object.create` on a "plain" object, the resulting object still doesn't have a constructor.
+ *   This can be useful for a "class instance" check.
+ *   Use {@link hasProto} if trying to see if the object doesn't have a prototype.
+ *
+ * Combining this with {@link isRegularObject}/{@link isObjectLike} makes the most sense.
+ *
+ * It is a bit tricky to consider all use cases, so it is up to the implementer.
+ * ```ts
+ * const isUserLandClassInstance = (value) => isRegularObject(value) && hasCtor(value);
+ * const isPlainObject = (value) => isObject(value) && !hasConstructor(value) && !Object.getPrototypeOf(value)
+ * ```
+ */
+export const hasCtor = (value: object) =>
+  // Has the object been created with a prototype?
+  // `Object.create(null)` creates an object without it.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  typeof value.constructor === 'function' &&
+  // And that prototype is not the base object (i.e. `{}`).
+  value.constructor !== Object;
+
+/**
+ * Does the object have a (non-base object) prototype?
+ *
+ * This doesn't care if the object has its own constructor.
+ *
+ * ## Input Matrix
+ *
+ * | Input                 | Constructor/Prototype | `hasProto` | `hasCtor` |
+ * |-----------------------|-----------------------|------------|-----------|
+ * | `new Foo()`           | `Foo`                 | `true`     | `true`    |
+ * | `{}`                  | `Object`              | `false`    | `false`   |
+ * | `Object.create(foo)`  | `Foo`                 | `true`     | `true`    |
+ * | `Object.create({})`   | `Object`              | `true`     | `false`   |
+ * | `Object.create(null)` | `null`                | `false`    | `false`   |
+ * | `""`                  | `String`              | `true`     | `true`    |
+ * | `[]`                  | `Array`               | `true`     | `true`    |
+ *
+ * A couple of notes:
+ * - Primitives & builtin objects have non-object prototypes.
+ * - When using `Object.create` on a "plain" object, the resulting object's prototype is the input.
+ *   This can be surprising if using it for a "plain object" check.
+ *   Use {@link hasCtor} if that logic is preferred.
+ *
+ * Combining this with {@link isRegularObject}/{@link isObjectLike} makes the most sense.
+ */
+export const hasProto = (value: object) => {
+  const proto = Object.getPrototypeOf(value);
+  return proto !== Object.prototype && proto != null;
+};

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -22,6 +22,7 @@ export * from './set-has.js';
 export * from './set-of.js';
 export * from './simple-switch.js';
 export * from './sort-by.js';
+export * from './to-json.js';
 export * from './to-primitive.js';
 export * from './to-string-tag.js';
 export type * from './types.js';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -20,4 +20,5 @@ export * from './set-has.js';
 export * from './set-of.js';
 export * from './simple-switch.js';
 export * from './sort-by.js';
+export * from './to-string-tag.js';
 export type * from './types.js';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -22,5 +22,6 @@ export * from './set-has.js';
 export * from './set-of.js';
 export * from './simple-switch.js';
 export * from './sort-by.js';
+export * from './to-primitive.js';
 export * from './to-string-tag.js';
 export type * from './types.js';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -8,6 +8,7 @@ export * from './delay.js';
 export * from './entries.js';
 export * from './group-by.js';
 export * from './is-not-falsy.js';
+export * from './is-object.js';
 export * from './inspect.js';
 export * from './iterator.js';
 export * from './json-col.js';

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -7,6 +7,7 @@ export * from './clean-join.js';
 export * from './delay.js';
 export * from './entries.js';
 export * from './group-by.js';
+export * from './has-ctor-proto.js';
 export * from './is-not-falsy.js';
 export * from './is-object.js';
 export * from './inspect.js';

--- a/packages/common/src/inspect.ts
+++ b/packages/common/src/inspect.ts
@@ -221,7 +221,7 @@ const wrapInspect = <TThis>(
 const setInspectRaw = <T>(object: T, fn: NativeInspectFn<T>): T =>
   Object.defineProperty(object, inspectSymbol, {
     value: fn,
-    enumerable: false,
+    configurable: true,
   });
 // Not using `inspect.custom` to avoid runtime imports
 const inspectSymbol = Symbol.for('nodejs.util.inspect.custom');

--- a/packages/common/src/is-object.ts
+++ b/packages/common/src/is-object.ts
@@ -1,0 +1,15 @@
+/**
+ * Does the value represent some kind of object?
+ *
+ * Plain objects & class instances are object like.
+ * Builtin objects like `Date`, `Array`, `Map`, `Set`, `Error`, etc. are as well.
+ *
+ * Primitives like, `string`, `boolean`, `numbers`, `bigint`, `null`, `undefined`, `functions`, etc. aren't.
+ *
+ * Other implementations:
+ * - lodash isObjectLike
+ * - @nestjs/common/utils/shared.utils.js isObject
+ * - @apollo/client/utilities isNonNullObject
+ */
+export const isObjectLike = (value: unknown): value is object =>
+  value != null && typeof value === 'object';

--- a/packages/common/src/is-object.ts
+++ b/packages/common/src/is-object.ts
@@ -1,3 +1,6 @@
+import { hasProto } from './has-ctor-proto.js';
+import { toStringTag } from './to-string-tag.js';
+
 /**
  * Does the value represent some kind of object?
  *
@@ -13,3 +16,77 @@
  */
 export const isObjectLike = (value: unknown): value is object =>
   value != null && typeof value === 'object';
+
+/**
+ * Is this value a plain object?
+ *
+ * Plain objects are created via object literals or with `Object.create(null)`
+ *
+ * Other implementations:
+ * - lodash
+ * - @nestjs/common/utils/shared.utils.js
+ * - @apollo/client/utilities
+ *
+ * I would consider a different implementation for this function,
+ * but it would be surprising to deviate from these other same-named, well-known other implementations.
+ * So this is here to continue to move away from lodash and avoid other library dependencies.
+ *
+ * Edge cases:
+ * - Plain objects that are "extended" with {@link Object.create} aren't considered plain.
+ *   ```ts
+ *   const base = { ... };
+ *   isPlainObject(base) === true
+ *   const sub = Object.create(base);
+ *   isPlainObject(sub) === false
+ *   ```
+ *   Why do this?
+ *   It is rare from what I've seen.
+ *   But it allows `base` to be modified and have those changes in `sub` as well as long as `sub` hasn't overridden.
+ *   This is the prototype chain.
+ *
+ * - Plain objects could have a custom {@link Symbol.toStringTag} defined.
+ *   ```ts
+ *   const opts = { ... };
+ *   setToStringTag(opts, 'MyOptions');
+ *   ```
+ *   This, in my opinion, _could_ be considered NOT a plain object anymore, but a custom one.
+ *   It is hard to say.
+ *
+ * ## Composing lower level functions
+ *
+ * The above edge cases are part of why I've exported lower-level functions to compose up slightly different logic.
+ * @example
+ * ```ts
+ * const isPlain = (value: unknown) => isObjectLike(value) && !hasCtor(value) && isObjectStringTag(value)
+ * isPlain(new Foo()) === false
+ * isPlain({}) === true
+ * isPlain(Object.create({})) === true
+ * isPlain(setToStringTag({}, 'Options')) === false
+ * ```
+ */
+export const isPlainObject = (value: unknown): value is object =>
+  isObjectLike(value) && !hasProto(value);
+
+/**
+ * Does the value represent some kind of regular object?
+ *
+ * Plain objects & class instances are by default, unless
+ * they've specified a custom {@link Symbol.toStringTag}.
+ *
+ * Builtin objects like `Date`, `Array`, `Map`, `Set`, `Error`, `URL`, etc. aren't,
+ * as they have a specific {@link Symbol.toStringTag}.
+ */
+export const isRegularObject = (value: unknown): value is object =>
+  isObjectLike(value) && isObjectStringTag(value);
+
+/**
+ * Does this value have a regular "Object" toStringTag?
+ *
+ * Plain objects & class instances by default do, unless
+ * they've specified a custom {@link Symbol.toStringTag}.
+ *
+ * Builtin objects like `Date`, `Array`, `Map`, `Set`, `Error`, `URL`, etc. aren't,
+ * as they have a specific {@link Symbol.toStringTag}.
+ */
+export const isObjectStringTag = (value: unknown) =>
+  toStringTag(value) === 'Object';

--- a/packages/common/src/to-json.test.ts
+++ b/packages/common/src/to-json.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'vitest';
+import { setToJson } from './to-json.js';
+
+test('setToJson works', () => {
+  class Foo {
+    hi = 'hi';
+  }
+  const foo = new Foo();
+
+  setToJson(Foo, (f) => f.hi);
+  expect(JSON.stringify(foo)).toBe('"hi"');
+
+  setToJson(Foo, function () {
+    return this.hi;
+  });
+  expect(JSON.stringify(foo)).toBe('"hi"');
+
+  const plain = { hi: 'hi' };
+  setToJson(plain, (p) => p.hi);
+  expect(JSON.stringify(plain)).toBe('"hi"');
+  setToJson(plain, function () {
+    return this.hi;
+  });
+  expect(JSON.stringify(plain)).toBe('"hi"');
+});

--- a/packages/common/src/to-json.ts
+++ b/packages/common/src/to-json.ts
@@ -1,0 +1,24 @@
+import { defineClassProp } from './define-class-prop.js';
+
+/**
+ * A small helper to define the toJSON for the class or object.
+ *
+ * Useful to customize how the object is serialized with {@link JSON.stringify}
+ *
+ * This keeps the method out of the public shape, which is good because it is not meant to be called directly.
+ * However, if private access is needed, this will not work.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#tojson_behavior
+ */
+export const setToJson = <
+  Cls extends { prototype: unknown } | object,
+  T = Cls extends { prototype: infer I } ? I : Cls,
+>(
+  classOrObject: Cls,
+  toJson: (this: T, instance: T, key: string) => unknown,
+) =>
+  defineClassProp(classOrObject, 'toJSON', {
+    value: function toJSON(this: T, key: string) {
+      return toJson.call(this, this, key);
+    },
+  });

--- a/packages/common/src/to-primitive.test.ts
+++ b/packages/common/src/to-primitive.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest';
+import { setToPrimitive } from './to-primitive.js';
+
+test('setToPrimitive works', () => {
+  class Foo {
+    hi = 'hi';
+  }
+  const foo = new Foo();
+
+  setToPrimitive(Foo, (f, hint) =>
+    hint === 'string' ? f.hi : hint === 'number' ? 5 : 'def',
+  );
+  expect(String(foo)).toBe('hi');
+  expect(+foo).toBe(5);
+  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+  expect(foo + '').toBe('def');
+});

--- a/packages/common/src/to-primitive.ts
+++ b/packages/common/src/to-primitive.ts
@@ -1,0 +1,26 @@
+import type { Primitive } from 'type-fest';
+import { defineClassProp } from './define-class-prop.js';
+
+export type PrimitiveHint = 'string' | 'number' | 'default';
+
+/**
+ * A small helper to define how to convert the class or object to a primitive.
+ *
+ * This keeps the method out of the public shape, which is good because it is not meant to be called directly.
+ * However, if private access is needed, this will not work.
+ *
+ * @see Symbol.toPrimitive
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive
+ */
+export const setToPrimitive = <
+  Cls extends { prototype: unknown } | object,
+  T = Cls extends { prototype: infer I } ? I : Cls,
+>(
+  classOrObject: Cls,
+  toPrimitiveFn: (this: T, instance: T, hint: PrimitiveHint) => Primitive,
+) =>
+  defineClassProp(classOrObject, Symbol.toPrimitive, {
+    value: function toPrimitive(this: T, hint: PrimitiveHint) {
+      return toPrimitiveFn.call(this, this, hint);
+    },
+  });

--- a/packages/common/src/to-string-tag.test.ts
+++ b/packages/common/src/to-string-tag.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'vitest';
+import { toStringTag } from './to-string-tag.js';
+
+test('toStringTag works', () => {
+  expect(toStringTag({})).toBe('Object');
+  expect(toStringTag([])).toBe('Array');
+});

--- a/packages/common/src/to-string-tag.test.ts
+++ b/packages/common/src/to-string-tag.test.ts
@@ -1,7 +1,20 @@
 import { expect, test } from 'vitest';
-import { toStringTag } from './to-string-tag.js';
+import { setToStringTag, toStringTag } from './to-string-tag.js';
 
 test('toStringTag works', () => {
   expect(toStringTag({})).toBe('Object');
   expect(toStringTag([])).toBe('Array');
+});
+
+test('setToStringTag works', () => {
+  class Foo {
+    hi = 'hi';
+  }
+  const foo = new Foo();
+
+  setToStringTag(Foo, 'F');
+  expect(toStringTag(foo)).toBe('F');
+
+  setToStringTag(Foo, (f) => f.hi);
+  expect(toStringTag(foo)).toBe('hi');
 });

--- a/packages/common/src/to-string-tag.ts
+++ b/packages/common/src/to-string-tag.ts
@@ -1,0 +1,18 @@
+/**
+ * Get the string representation of the object.
+ *
+ * This automatically unwraps the tag from the "[object Tag]" notation.
+ *
+ * Use with caution, because prototype pollution blah blah.
+ * There are also better, more-typed ways to check for specific types.
+ *
+ * @example
+ * toStringTag({}) -> "Object"
+ * toStringTag([]) -> "Array"
+ * toStringTag(new Map) -> "Map"
+ *
+ * @see Symbol.toStringTag
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag
+ */
+export const toStringTag = (value: unknown) =>
+  Object.prototype.toString.call(value).slice(8, -1);

--- a/packages/common/src/to-string-tag.ts
+++ b/packages/common/src/to-string-tag.ts
@@ -1,3 +1,5 @@
+import { defineClassProp } from './define-class-prop.js';
+
 /**
  * Get the string representation of the object.
  *
@@ -16,3 +18,28 @@
  */
 export const toStringTag = (value: unknown) =>
   Object.prototype.toString.call(value).slice(8, -1);
+
+/**
+ * A small helper to define the {@link Symbol.toStringTag} for the class or object.
+ *
+ * Useful to convey that the class/object is not a "regular" object.
+ * @see isRegularObject
+ */
+export const setToStringTag = <
+  Cls extends { prototype: unknown } | object,
+  T = Cls extends { prototype: infer I } ? I : Cls,
+>(
+  classOrObject: Cls,
+  tag: string | ((this: T, instance: T) => string),
+) =>
+  defineClassProp(
+    classOrObject,
+    Symbol.toStringTag,
+    typeof tag === 'string'
+      ? { value: tag }
+      : {
+          get: function toStringTag(this: T) {
+            return tag.call(this, this);
+          },
+        },
+  );


### PR DESCRIPTION
Not listed here is how all of these will be used.
- `isPlainObject` is an obvious replacement from lodash / other libraries.
- The setters will be applied the scripture `Book/Chapter/Verse` objects, but are not here due to the poor CI release constraints.
- Some sort of `isClassInstance` logic will be formed to the version in Seed API. And to move the ClassTransformer patch here. I couldn't distill an implementation of this function that would make sense for every use case, so I didn't create this function. But it should be easy to compose with the lower level functions given here.
- `setToStringTag` along with some form of [isPlain](https://github.com/SeedCompany/libs/pull/44/files#diff-cdb43a712d28d0c991b80675d42518b29cd4de148e5893034bb15c869ed5667dR60) could be used to traverse deeply through "data" objects while understanding when to stop at scalar instances.