### PR TITLE
fix(email): hide emailjs usage from TS

### DIFF
--- a/packages/email/src/email.service.ts
+++ b/packages/email/src/email.service.ts
@@ -94,7 +94,10 @@ export class EmailService {
   }
 
   async sendMessage(msg: EmailMessage) {
-    const encoded = await msg.readAsync();
+    // "dynamic" import to hide library source usage
+    const EmailJS = await import(String('emailjs'));
+    const encoded: string = await new EmailJS.Message(msg.headers).readAsync();
+
     const command = new SendEmailCommand({
       Content: {
         Raw: {
@@ -137,7 +140,7 @@ export class EmailService {
         table: (el, walk, builder, options) =>
           el.attribs.role === 'presentation'
             ? walk(el.children, builder)
-            : builder.options.formatters.dataTable(el, walk, builder, options),
+            : builder.options.formatters.dataTable!(el, walk, builder, options),
       },
     });
 

--- a/packages/email/src/message.ts
+++ b/packages/email/src/message.ts
@@ -1,19 +1,76 @@
-import { Message, type MessageHeaders } from 'emailjs';
+import type { PathLike } from 'node:fs';
+import type { Readable } from 'node:stream';
 import { many } from './utils.js';
 
-export class EmailMessage extends Message {
+export class EmailMessage {
   readonly templateName: string;
   readonly to: readonly string[];
   readonly html: string;
+  readonly headers: Partial<MessageHeaders>;
 
   constructor({
     templateName,
     html,
     ...headers
   }: Partial<MessageHeaders> & { templateName: string; html: string }) {
-    super(headers);
     this.templateName = templateName;
     this.to = headers.to ? many(headers.to) : [];
     this.html = html;
+    this.headers = headers;
   }
+}
+
+// Below is inlined from the `emailjs` library to avoid using their loose source files
+
+interface MessageHeaders {
+  [index: string]:
+    | boolean
+    | string
+    | string[]
+    | null
+    | undefined
+    | MessageAttachment
+    | MessageAttachment[];
+  'content-type'?: string;
+  'message-id'?: string;
+  'return-path'?: string | null;
+  date?: string;
+  from: string | string[];
+  to: string | string[];
+  cc?: string | string[];
+  bcc?: string | string[];
+  subject: string;
+  text: string | null;
+  attachment?: MessageAttachment | MessageAttachment[];
+}
+
+interface MessageAttachment {
+  [index: string]:
+    | string
+    | boolean
+    | MessageAttachment
+    | MessageAttachment[]
+    | MessageAttachmentHeaders
+    | Readable
+    | PathLike
+    | undefined;
+  name?: string;
+  headers?: MessageAttachmentHeaders;
+  inline?: boolean;
+  alternative?: MessageAttachment | boolean;
+  related?: MessageAttachment[];
+  data?: string;
+  encoded?: boolean;
+  stream?: Readable;
+  path?: PathLike;
+  type?: string;
+  charset?: string;
+  method?: string;
+}
+
+interface MessageAttachmentHeaders {
+  [index: string]: string | undefined;
+  'content-type'?: string;
+  'content-transfer-encoding'?: BufferEncoding | '7bit' | '8bit';
+  'content-disposition'?: string;
 }

--- a/packages/email/src/templates/attachment.tsx
+++ b/packages/email/src/templates/attachment.tsx
@@ -1,14 +1,14 @@
-import type { MessageAttachment } from 'emailjs';
 import { createContext, type ReactNode, useContext } from 'react';
 
-export interface AttachmentProps
-  extends Partial<Pick<MessageAttachment, 'charset' | 'method'>> {
+export interface AttachmentProps {
   /** The file data */
   data: string;
   /** The file's content-type */
   type: string;
   /** The file's name */
   name: string;
+  charset?: string;
+  method?: string;
 }
 
 const AttachmentContext = createContext<AttachmentProps[]>([]);

--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": ["dist", "node_modules"],
   "compilerOptions": {
+    "noUncheckedIndexedAccess": true,
     "jsx": "react-jsx"
   }
 }


### PR DESCRIPTION
The library exposes its source as the type definitions, and its source does not meet the strictest standards. So we need to avoid TS pulling in these source files and checking them as if we own them.

Inline the shapes & dynamically import library.