### PR TITLE
feat(email): Better header composition & service API

### DIFF
--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -10,6 +10,7 @@
     "@aws-sdk/client-sesv2": "^3.658.1",
     "@faire/mjml-react": "^3.3.0",
     "@nestjs/common": ">=7.6.4",
+    "@seedcompany/common": ">=0.3.0 <1.0.0",
     "emailjs": "^4.0.3",
     "html-to-text": "^9.0.5",
     "mjml": "^4.15.3",

--- a/packages/email/src/email.module.ts
+++ b/packages/email/src/email.module.ts
@@ -1,5 +1,6 @@
 import { SESv2Client as SES } from '@aws-sdk/client-sesv2';
 import { type DynamicModule, Module, type Type } from '@nestjs/common';
+import type { MaybeAsync } from '@seedcompany/common';
 import {
   EMAIL_MODULE_OPTIONS,
   type EmailModuleOptions,
@@ -7,7 +8,6 @@ import {
   SES_TOKEN,
 } from './email.options.js';
 import { EmailService } from './email.service.js';
-import type { MaybeAsync } from './utils.js';
 
 export interface EmailOptionsFactory {
   createEmailOptions: () => MaybeAsync<EmailModuleOptions>;

--- a/packages/email/src/email.options.ts
+++ b/packages/email/src/email.options.ts
@@ -2,8 +2,8 @@ import {
   SESv2Client as SES,
   type SESv2ClientConfig,
 } from '@aws-sdk/client-sesv2';
+import type { Many } from '@seedcompany/common';
 import { type ReactElement } from 'react';
-import type { Many } from './utils.js';
 
 export const SES_TOKEN = Symbol('SES');
 

--- a/packages/email/src/email.service.ts
+++ b/packages/email/src/email.service.ts
@@ -48,7 +48,7 @@ export class EmailService {
     const msg = this.render(template, props).with({ to });
 
     if (send) {
-      await this.sendMessage(msg);
+      await this.transportMessage(msg);
       return;
     }
     this.logger.debug(
@@ -121,7 +121,14 @@ export class EmailService {
     return Promise.resolve(message);
   }
 
+  /**
+   * @deprecated
+   */
   async sendMessage(msg: EmailMessage) {
+    await this.transportMessage(msg);
+  }
+
+  private async transportMessage(msg: EmailMessage) {
     // "dynamic" import to hide library source usage
     const EmailJS = await import(String('emailjs'));
     const encoded: string = await new EmailJS.Message(msg.headers).readAsync();

--- a/packages/email/src/email.service.ts
+++ b/packages/email/src/email.service.ts
@@ -38,14 +38,23 @@ export class EmailService {
     });
   }
 
+  async send(message: EmailMessage): Promise<void>;
   async send<P extends object>(
     to: Many<string>,
     template: Component<P>,
     props: P,
+  ): Promise<void>;
+  async send<P extends object>(
+    to: Many<string> | EmailMessage,
+    template?: Component<P>,
+    props?: P,
   ): Promise<void> {
     const { send, open } = this.options;
 
-    const msg = this.render(template, props).with({ to });
+    const msg =
+      to instanceof EmailMessage
+        ? to
+        : this.render(template!, props!).with({ to });
 
     if (send) {
       await this.transportMessage(msg);

--- a/packages/email/src/email.service.ts
+++ b/packages/email/src/email.service.ts
@@ -5,7 +5,11 @@ import { delay, many, type Many } from '@seedcompany/common';
 import { promises as fs } from 'fs';
 import { htmlToText } from 'html-to-text';
 import openUrl from 'open';
-import { createElement, type ReactElement } from 'react';
+import {
+  type FunctionComponent as Component,
+  createElement,
+  type ReactElement as Element,
+} from 'react';
 import { temporaryFile as tempFile } from 'tempy';
 import {
   EMAIL_MODULE_OPTIONS,
@@ -36,7 +40,7 @@ export class EmailService {
 
   async send<P extends object>(
     to: Many<string>,
-    template: (props: P) => ReactElement,
+    template: Component<P>,
     props: P,
   ): Promise<void> {
     const { send, open } = this.options;
@@ -60,7 +64,7 @@ export class EmailService {
 
   async render<P extends object>(
     to: Many<string>,
-    template: (props: P) => ReactElement,
+    template: Component<P>,
     props: P,
   ) {
     const subjectRef = new SubjectCollector();
@@ -71,7 +75,7 @@ export class EmailService {
       subjectRef.collect,
       attachmentsRef.collect,
     ].reduceRight(
-      (prev: ReactElement, wrap) => wrap(prev),
+      (prev: Element, wrap) => wrap(prev),
       createElement(template, props),
     );
 
@@ -127,12 +131,12 @@ export class EmailService {
     }
   }
 
-  private renderHtml(templateEl: ReactElement) {
+  private renderHtml(templateEl: Element) {
     const { html } = render(templateEl);
     return html;
   }
 
-  private renderText(templateEl: ReactElement) {
+  private renderText(templateEl: Element) {
     const { html: htmlForText } = render(
       createElement(RenderForText, null, templateEl),
     );

--- a/packages/email/src/email.service.ts
+++ b/packages/email/src/email.service.ts
@@ -26,6 +26,14 @@ export class EmailService {
     @Inject(EMAIL_MODULE_OPTIONS) private readonly options: EmailOptions,
   ) {}
 
+  withOptions(options: Omit<Partial<EmailOptions>, 'ses'>) {
+    return new EmailService(this.ses, {
+      ...this.options,
+      ...options,
+      wrappers: [...this.options.wrappers, ...(options.wrappers ?? [])],
+    });
+  }
+
   async send<P extends object>(
     to: Many<string>,
     template: (props: P) => ReactElement,

--- a/packages/email/src/email.service.ts
+++ b/packages/email/src/email.service.ts
@@ -1,6 +1,7 @@
 import { SendEmailCommand, SESv2Client as SES } from '@aws-sdk/client-sesv2';
 import { render } from '@faire/mjml-react/utils/render.js';
 import { Inject, Injectable, Logger } from '@nestjs/common';
+import { delay, many, type Many } from '@seedcompany/common';
 import { promises as fs } from 'fs';
 import { htmlToText } from 'html-to-text';
 import openUrl from 'open';
@@ -15,7 +16,6 @@ import { EmailMessage } from './message.js';
 import { AttachmentCollector } from './templates/attachment.js';
 import { RenderForText } from './templates/text-rendering.js';
 import { SubjectCollector } from './templates/title.js';
-import { type Many, many, sleep } from './utils.js';
 
 @Injectable()
 export class EmailService {
@@ -152,7 +152,7 @@ export class EmailService {
     await fs.writeFile(temp, html);
     await openUrl(`file://${temp}`);
     // try to wait for chrome to open before deleting the temp file
-    void sleep(10_000)
+    void delay(10_000)
       .then(() => fs.rm(temp, { recursive: true, force: true, maxRetries: 2 }))
       .catch();
   }

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,3 +1,4 @@
+export * from './message.js';
 export * from './email.options.js';
 export * from './email.service.js';
 export * from './email.module.js';

--- a/packages/email/src/message.ts
+++ b/packages/email/src/message.ts
@@ -1,4 +1,4 @@
-import { many } from '@seedcompany/common';
+import { type Many, many } from '@seedcompany/common';
 import type { PathLike } from 'node:fs';
 import type { Readable } from 'node:stream';
 
@@ -21,35 +21,33 @@ export class EmailMessage {
 }
 
 // Below is inlined from the `emailjs` library to avoid using their loose source files
+// I changed to immutable
 
-interface MessageHeaders {
+type MessageHeaders = Readonly<{
   [index: string]:
     | boolean
-    | string
-    | string[]
+    | Many<string>
     | null
     | undefined
-    | MessageAttachment
-    | MessageAttachment[];
+    | Many<MessageAttachment>;
   'content-type'?: string;
   'message-id'?: string;
   'return-path'?: string | null;
   date?: string;
-  from: string | string[];
-  to: string | string[];
-  cc?: string | string[];
-  bcc?: string | string[];
+  from: Many<string>;
+  to: Many<string>;
+  cc?: Many<string>;
+  bcc?: Many<string>;
   subject: string;
   text: string | null;
-  attachment?: MessageAttachment | MessageAttachment[];
-}
+  attachment?: Many<MessageAttachment>;
+}>;
 
-interface MessageAttachment {
+type MessageAttachment = Readonly<{
   [index: string]:
     | string
     | boolean
-    | MessageAttachment
-    | MessageAttachment[]
+    | Many<MessageAttachment>
     | MessageAttachmentHeaders
     | Readable
     | PathLike
@@ -58,7 +56,7 @@ interface MessageAttachment {
   headers?: MessageAttachmentHeaders;
   inline?: boolean;
   alternative?: MessageAttachment | boolean;
-  related?: MessageAttachment[];
+  related?: readonly MessageAttachment[];
   data?: string;
   encoded?: boolean;
   stream?: Readable;
@@ -66,11 +64,11 @@ interface MessageAttachment {
   type?: string;
   charset?: string;
   method?: string;
-}
+}>;
 
-interface MessageAttachmentHeaders {
+type MessageAttachmentHeaders = Readonly<{
   [index: string]: string | undefined;
   'content-type'?: string;
   'content-transfer-encoding'?: BufferEncoding | '7bit' | '8bit';
   'content-disposition'?: string;
-}
+}>;

--- a/packages/email/src/message.ts
+++ b/packages/email/src/message.ts
@@ -18,6 +18,15 @@ export class EmailMessage {
     this.html = html;
     this.headers = headers;
   }
+
+  with(headers: Partial<MessageHeaders>) {
+    return new EmailMessage({
+      ...this.headers,
+      ...headers,
+      templateName: this.templateName,
+      html: this.html,
+    });
+  }
 }
 
 // Below is inlined from the `emailjs` library to avoid using their loose source files

--- a/packages/email/src/message.ts
+++ b/packages/email/src/message.ts
@@ -1,6 +1,6 @@
+import { many } from '@seedcompany/common';
 import type { PathLike } from 'node:fs';
 import type { Readable } from 'node:stream';
-import { many } from './utils.js';
 
 export class EmailMessage {
   readonly templateName: string;

--- a/packages/email/src/utils.ts
+++ b/packages/email/src/utils.ts
@@ -1,9 +1,0 @@
-export type MaybeAsync<T> = T | Promise<T>;
-
-export type Many<T> = T | readonly T[];
-
-export const many = <T>(item: Many<T>): readonly T[] =>
-  Array.isArray(item) ? item : [item as T];
-
-export const sleep = (ms: number) =>
-  new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -4,6 +4,10 @@
   "exclude": ["dist", "node_modules"],
   "compilerOptions": {
     "noUncheckedIndexedAccess": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@seedcompany/common": ["../common/src"],
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3991,6 +3991,7 @@ __metadata:
     "@nestjs/core": "npm:^10.4.4"
     "@nestjs/platform-express": "npm:^10.4.4"
     "@nestjs/testing": "npm:^10.4.4"
+    "@seedcompany/common": "npm:>=0.3.0 <1.0.0"
     "@types/html-to-text": "npm:^9.0.4"
     "@types/mjml-core": "npm:^4.15.0"
     "@types/react": "npm:^18.3.9"


### PR DESCRIPTION
```diff
const emailService: EmailService

- await emailService.render(to, template, props)
+ emailService.render(template, props).with({ to })

- await emailService.sendMessage(await emailService.render(to, template, props))
+ await emailService.send(emailService.render(template, props).with({ to }))
or
+ await emailService.render(template, props).with({ to }).send()
```