### PR TITLE
feat(nest): add validator module to register global pipe & support injectable constraints

### DIFF
--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -13,6 +13,7 @@
     "@seedcompany/common": ">=0.17 <1",
     "change-case": "^5.4.4",
     "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.2",
     "title-case": "^4.3.1",
     "type-fest": "^4.26.1",
     "uuid": "^11.0.0-0"
@@ -22,6 +23,7 @@
     "@nestjs/core": "^10 || ^11",
     "@nestjs/graphql": "^12 || ^13",
     "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
     "reflect-metadata": "^0.1.12 || ^0.2.0"
   },
   "scripts": {

--- a/packages/nest/src/index.ts
+++ b/packages/nest/src/index.ts
@@ -4,3 +4,4 @@ export * from './repl.js';
 export * from './metadata-decorator.js';
 export * from './patch-decorated-method.js';
 export { markSkipClassTransformation } from './patches/class-transformer.patch.js';
+export { ValidatorModule } from './validator/validator.module.js';

--- a/packages/nest/src/validator/validation.pipe.ts
+++ b/packages/nest/src/validator/validation.pipe.ts
@@ -1,0 +1,41 @@
+import {
+  ValidationPipe as BaseValidationPipe,
+  Inject,
+  Injectable,
+  type ValidationPipeOptions,
+} from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import { useContainer, type ValidatorOptions } from 'class-validator';
+import { MODULE_OPTIONS_TOKEN } from './validator.module.js';
+
+/**
+ * Wraps Nest's ValidationPipe to support injectable constraints.
+ */
+@Injectable()
+export class ValidationPipe extends BaseValidationPipe {
+  constructor(
+    @Inject(MODULE_OPTIONS_TOKEN) options: ValidationPipeOptions,
+    private readonly moduleRef: ModuleRef,
+  ) {
+    super(options);
+  }
+
+  private readonly iocContainer = {
+    get: (type: any) => {
+      if (type.name === 'CustomConstraint') {
+        // A prototype-less constraint.
+        // Return null to fall back to default logic, which just calls constructor once.
+        return null;
+      }
+      return this.moduleRef.get(type);
+    },
+  };
+
+  protected async validate(
+    object: object,
+    validatorOptions?: ValidatorOptions,
+  ) {
+    useContainer(this.iocContainer, { fallback: true });
+    return await super.validate(object, validatorOptions);
+  }
+}

--- a/packages/nest/src/validator/validator.module.ts
+++ b/packages/nest/src/validator/validator.module.ts
@@ -1,0 +1,29 @@
+import {
+  ConfigurableModuleBuilder,
+  Module,
+  ValidationPipe as NestValidationPipe,
+  type ValidationPipeOptions,
+} from '@nestjs/common';
+import { APP_PIPE } from '@nestjs/core';
+import { Validator } from 'class-validator';
+import { ValidationPipe } from './validation.pipe.js';
+
+const { ConfigurableModuleClass, MODULE_OPTIONS_TOKEN } =
+  new ConfigurableModuleBuilder<ValidationPipeOptions>().build();
+
+export { MODULE_OPTIONS_TOKEN };
+
+/**
+ * The missing module to register the class-validator as a global pipe.
+ * This also allows for injectable constraints.
+ */
+@Module({
+  providers: [
+    Validator,
+    ValidationPipe,
+    { provide: NestValidationPipe, useExisting: ValidationPipe },
+    { provide: APP_PIPE, useExisting: ValidationPipe },
+  ],
+  exports: [ValidationPipe],
+})
+export class ValidatorModule extends ConfigurableModuleClass {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3985,6 +3985,7 @@ __metadata:
     "@seedcompany/common": "npm:>=0.17 <1"
     change-case: "npm:^5.4.4"
     class-transformer: "npm:^0.5.1"
+    class-validator: "npm:^0.14.2"
     graphql: "npm:^16.9.0"
     reflect-metadata: "npm:^0.2.2"
     rxjs: "npm:^7.8.1"
@@ -3996,6 +3997,7 @@ __metadata:
     "@nestjs/core": ^10 || ^11
     "@nestjs/graphql": ^12 || ^13
     class-transformer: ^0.5.1
+    class-validator: ^0.14.0
     reflect-metadata: ^0.1.12 || ^0.2.0
   languageName: unknown
   linkType: soft
@@ -4947,6 +4949,13 @@ __metadata:
   dependencies:
     "@types/superagent": "npm:*"
   checksum: 10c0/64ba18395a8e673cce9a4ffcdda7234d2f9982d737a2eb9289c1268ff148e410a1a1d8b7a4f42498511457ad9f51b9b4d53832fbdef3d86aff7bdfbcfe7610ab
+  languageName: node
+  linkType: hard
+
+"@types/validator@npm:^13.11.8":
+  version: 13.15.2
+  resolution: "@types/validator@npm:13.15.2"
+  checksum: 10c0/2c7ce5b745e2c856d0ecd193469cf0edd5081b17208dfab4f03dd5801b8893dcf4cbcfcb662c2b6a42032940effd33e16a56a7eba9e2776b1804111118e320dc
   languageName: node
   linkType: hard
 
@@ -6180,6 +6189,17 @@ __metadata:
   version: 0.5.1
   resolution: "class-transformer@npm:0.5.1"
   checksum: 10c0/19809914e51c6db42c036166839906420bb60367df14e15f49c45c8c1231bf25ae661ebe94736ee29cc688b77101ef851a8acca299375cc52fc141b64acde18a
+  languageName: node
+  linkType: hard
+
+"class-validator@npm:^0.14.2":
+  version: 0.14.2
+  resolution: "class-validator@npm:0.14.2"
+  dependencies:
+    "@types/validator": "npm:^13.11.8"
+    libphonenumber-js: "npm:^1.11.1"
+    validator: "npm:^13.9.0"
+  checksum: 10c0/5bb67389d38fa23d342dffdd8e2dcee8235e1906e59799df5b2050278a6d89292fcaa88167f0215e3ddd684f47dcd51b004efa7be32d8aded91ee06cb317b3b8
   languageName: node
   linkType: hard
 
@@ -10073,6 +10093,13 @@ __metadata:
     prelude-ls: "npm:^1.2.1"
     type-check: "npm:~0.4.0"
   checksum: 10c0/effb03cad7c89dfa5bd4f6989364bfc79994c2042ec5966cb9b95990e2edee5cd8969ddf42616a0373ac49fac1403437deaf6e9050fbbaa3546093a59b9ac94e
+  languageName: node
+  linkType: hard
+
+"libphonenumber-js@npm:^1.11.1":
+  version: 1.12.10
+  resolution: "libphonenumber-js@npm:1.12.10"
+  checksum: 10c0/c348aee275c4161e289b14f2ffd0c00f2923dcd5b2cfd99415b2f5ea15fa0632adffb78c51373b3a2839416223b65452bee11cc5386d2352782e1b064aaaf0ce
   languageName: node
   linkType: hard
 
@@ -14406,6 +14433,13 @@ __metadata:
     spdx-correct: "npm:^3.0.0"
     spdx-expression-parse: "npm:^3.0.0"
   checksum: 10c0/7b91e455a8de9a0beaa9fe961e536b677da7f48c9a493edf4d4d4a87fd80a7a10267d438723364e432c2fcd00b5650b5378275cded362383ef570276e6312f4f
+  languageName: node
+  linkType: hard
+
+"validator@npm:^13.9.0":
+  version: 13.15.15
+  resolution: "validator@npm:13.15.15"
+  checksum: 10c0/f5349d1fbb9cc36f9f6c5dab1880764ddad1d0d2b084e2a71e5964f7de1635d20e406611559df9a3db24828ce775cbee5e3b6dd52f0d555a61939ed7ea5990bd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Register global validation pipe in App module:
```ts
ValidatorModule.register({})
```

# Injectable Constraints
```ts
@Injectable()
@ValidatorConstraint({ name: 'Foo', async: true })
export class FooConstraint implements ValidatorConstraintInterface {
  constructor(private readonly bar: BarService) {}

  async validate(value: unknown, args: ValidationArguments) {
   ...
  }
}

@Module({
  providers: [FooConstraint],
})
class FooModule {}


class DTO {
  @Validate(FooConstraint)
  field: string;
}
```