### PR TITLE
feat(nest): additional decorators with metadata decorator

### DIFF
--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -10,7 +10,7 @@
     "@nestjs/common": "^10 || ^11",
     "@nestjs/core": "^10 || ^11",
     "@nestjs/graphql": "^12 || ^13",
-    "@seedcompany/common": ">=0.17 <1",
+    "@seedcompany/common": ">=0.21 <1",
     "change-case": "^5.4.4",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3884,7 +3884,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@seedcompany/common@npm:>=0.17 <1, @seedcompany/common@npm:>=0.17 <1.0.0, @seedcompany/common@npm:>=0.21 <1, @seedcompany/common@npm:>=0.3.0 <1.0.0, @seedcompany/common@workspace:packages/common":
+"@seedcompany/common@npm:>=0.17 <1.0.0, @seedcompany/common@npm:>=0.21 <1, @seedcompany/common@npm:>=0.3.0 <1.0.0, @seedcompany/common@workspace:packages/common":
   version: 0.0.0-use.local
   resolution: "@seedcompany/common@workspace:packages/common"
   dependencies:
@@ -4008,7 +4008,7 @@ __metadata:
     "@nestjs/core": "npm:^10 || ^11"
     "@nestjs/graphql": "npm:^12 || ^13"
     "@nestjs/testing": "npm:^11.0.11"
-    "@seedcompany/common": "npm:>=0.17 <1"
+    "@seedcompany/common": "npm:>=0.21 <1"
     change-case: "npm:^5.4.4"
     class-transformer: "npm:^0.5.1"
     class-validator: "npm:^0.14.2"


### PR DESCRIPTION
This allows us to not have to wrap the created decorator, requiring a second export for the wrapped function along with the original for discovery.

This
```ts
// export needed for discovery
export const FooInner = createMetadataDecorator({
  types: ['class'],
});

// export for expected use across codebase
export const Foo = () => (cls: AbstractClass<any>) =>
  applyDecorators(Injectable(), FooInner())(cls);
```
can become this:
```ts
// single, unified export
export const Foo = createMetadataDecorator({
  types: ['class'],
  additionalDecorators: [Injectable()],
});
```