### PR TITLE
feat(common): `CachedGetter`

### DIFF
--- a/packages/common/src/cache/CachedGetter.ts
+++ b/packages/common/src/cache/CachedGetter.ts
@@ -1,0 +1,39 @@
+/**
+ * Decorate a getter to only execute it once and cache the result.
+ *
+ * @example
+ * ```ts
+ * class Foo {
+ *   @CachedGetter() get bar() {
+ *     // this will only be executed once, and the result will be cached
+ *     return 42;
+ *   }
+ * }
+ * ```
+ *
+ * @see Adapted from https://github.com/Alorel/typescript-lazy-get-decorator
+ */
+export const CachedGetter =
+  (): MethodDecorator => (target, key, descriptor) => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const getter = descriptor.get;
+    if (!getter) {
+      throw new Error(`@${CachedGetter.name} can only decorate getters`);
+    }
+    if (!descriptor.configurable) {
+      throw new Error(`@${CachedGetter.name} target must be configurable`);
+    }
+
+    const opts = {
+      configurable: true,
+      enumerable: descriptor.enumerable,
+    } satisfies PropertyDescriptor;
+    return {
+      ...opts,
+      get: function () {
+        const value = getter.apply(this);
+        Object.defineProperty(this, key, { ...opts, value });
+        return value;
+      },
+    };
+  };

--- a/packages/common/src/cache/index.ts
+++ b/packages/common/src/cache/index.ts
@@ -2,3 +2,4 @@ export * from './CachableMap.js';
 export * from './cached.js';
 export * from './cachable.js';
 export * from './CachedByArg.js';
+export * from './CachedGetter.js';


### PR DESCRIPTION
To replace `@LazyGetter()` from https://github.com/Alorel/typescript-lazy-get-decorator.
That library has a bunch of stuff we don't need, and it's latest version is only for ECMA decorators.
It doesn't make sense to keep carrying this library, when we can just inline this small function in ours.