### PR TITLE
feat(common): keys

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -13,6 +13,7 @@ export * from './is-object.js';
 export * from './inspect.js';
 export * from './iterator.js';
 export * from './json-col.js';
+export * from './keys.js';
 export * from './many.js';
 export * from './map-of.js';
 export * from './map-to.js';

--- a/packages/common/src/keys.ts
+++ b/packages/common/src/keys.ts
@@ -1,0 +1,17 @@
+import { entries } from './entries.js';
+
+/**
+ * Returns an array of keys for the given mapping.
+ *
+ * This is mainly for Records, where we can't use {@link Object.keys} with strict keys.
+ * But this also accepts an {@link Iterable}, so it works with Maps or an array of entries.
+ */
+export function keys<K>(
+  map: Iterable<readonly [key: K, value: any]>,
+): readonly K[];
+export function keys<T extends object>(
+  object: T,
+): ReadonlyArray<keyof T & string>;
+export function keys<K>(o: any): readonly K[] {
+  return entries<K, unknown>(o).map(([key]) => key);
+}


### PR DESCRIPTION
I initially tried to avoid this function, because I was hopeful that `entries` would be a singular function that would handle both cases.
I've concluded though that that strategy can be too verbose and unintuitive to read.

So here's the small helper that thinly wraps `entries` and maps to just the key.